### PR TITLE
fix: marketplace.jsonの`source`を正しいパス形式に修正

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "kyosei",
-      "source": "kyosei"
+      "source": "./plugins/kyosei"
     }
   ]
 }


### PR DESCRIPTION
`"kyosei"`という省略形はスキーマに合わないため、
`"./plugins/kyosei"`に修正しました。
