### PR TITLE
fix(ci): `claude-code-action`に`plugin_marketplaces`と`plugins`を追加

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -49,6 +49,10 @@ jobs:
         continue-on-error: true
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # マーケットプレイスを認識させます。
+          plugin_marketplaces: "https://github.com/ncaq/konoka.git"
+          # 利用プラグインを指定します。
+          plugins: "kyosei@konoka"
           # 通常のClaude Codeがセットアップするレビュープラグインではなく、Kyoseiプラグインを利用するための指定です。
           prompt: "/kyosei REPO:${{ github.repository }} PR_NUMBER:${{ github.event.pull_request.number }}"
           # botだからといって人間のコミットと危険性は特に変わらないはずなので許可します。

--- a/plugins/kyosei/examples/claude-code-review.yml
+++ b/plugins/kyosei/examples/claude-code-review.yml
@@ -49,6 +49,10 @@ jobs:
         continue-on-error: true
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # マーケットプレイスを認識させます。
+          plugin_marketplaces: "https://github.com/ncaq/konoka.git"
+          # 利用プラグインを指定します。
+          plugins: "kyosei@konoka"
           # 通常のClaude Codeがセットアップするレビュープラグインではなく、Kyoseiプラグインを利用するための指定です。
           prompt: "/kyosei REPO:${{ github.repository }} PR_NUMBER:${{ github.event.pull_request.number }}"
           # botだからといって人間のコミットと危険性は特に変わらないはずなので許可します。


### PR DESCRIPTION
CI環境ではマーケットプレイスプラグインが自動解決されないため、
`/kyosei`スラッシュコマンドが認識されずレビューが実行されていませんでした。
`claude-code-action`の`plugin_marketplaces`と`plugins`パラメータを明示的に指定することで、
CI環境でもkyoseiプラグインがインストールされるようにします。

close #9