### PR TITLE
docs(README): 原則日本語にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Claude Codeプラグインマーケットプレイスとして配布していま
 
 ## Install
 
-In Claude Code.
+Claude Codeで以下を実行します。
 
 ```text
 /plugin marketplace add ncaq/konoka
 ```
 
-Or in project `.claude/settings.json`.
+または`.claude/settings.json`に追加します。
 
 ```json
 {

--- a/plugins/bump-cabal-index-state/README.md
+++ b/plugins/bump-cabal-index-state/README.md
@@ -9,15 +9,15 @@ haskell.nixの対応遅れにも対応しており、認識済みの最新値に
 
 ## インストール
 
-Before installing this plugin, first add the [ncaq/konoka](../../README.md) marketplace to Claude Code.
+このプラグインをインストールする前に、[ncaq/konoka](../../README.md)マーケットプレイスをClaude Codeに追加してください。
 
-In Claude Code.
+Claude Codeで以下を実行します。
 
 ```text
 /plugin install bump-cabal-index-state@konoka
 ```
 
-Or in project `.claude/settings.json`.
+または`.claude/settings.json`に追加します。
 
 ```json
 {

--- a/plugins/commit/README.md
+++ b/plugins/commit/README.md
@@ -8,15 +8,15 @@ AI-assisted git commit with editor review.
 
 ## インストール
 
-Before installing this plugin, first add the [ncaq/konoka](../../README.md) marketplace to Claude Code.
+このプラグインをインストールする前に、[ncaq/konoka](../../README.md)マーケットプレイスをClaude Codeに追加してください。
 
-In Claude Code.
+Claude Codeで以下を実行します。
 
 ```text
 /plugin install commit@konoka
 ```
 
-Or in project `.claude/settings.json`.
+または`.claude/settings.json`に追加します。
 
 ```json
 {

--- a/plugins/kyosei/README.md
+++ b/plugins/kyosei/README.md
@@ -37,15 +37,15 @@ pushしてCIの完了を待つことなく手元で即座にレビューを確�
 
 ## インストール
 
-Before installing this plugin, first add the [ncaq/konoka](../../README.md) marketplace to Claude Code.
+このプラグインをインストールする前に、[ncaq/konoka](../../README.md)マーケットプレイスをClaude Codeに追加してください。
 
-In Claude Code.
+Claude Codeで以下を実行します。
 
 ```text
 /plugin install kyosei@konoka
 ```
 
-Or in project `.claude/settings.json`.
+または`.claude/settings.json`に追加します。
 
 ```json
 {

--- a/plugins/log-analyzer/README.md
+++ b/plugins/log-analyzer/README.md
@@ -7,15 +7,15 @@ Extract key information from verbose command output while keeping main conversat
 
 ## インストール
 
-Before installing this plugin, first add the [ncaq/konoka](../../README.md) marketplace to Claude Code.
+このプラグインをインストールする前に、[ncaq/konoka](../../README.md)マーケットプレイスをClaude Codeに追加してください。
 
-In Claude Code.
+Claude Codeで以下を実行します。
 
 ```text
 /plugin install log-analyzer@konoka
 ```
 
-Or in project `.claude/settings.json`.
+または`.claude/settings.json`に追加します。
 
 ```json
 {

--- a/plugins/research/README.md
+++ b/plugins/research/README.md
@@ -6,15 +6,15 @@ Cross-source search for technical investigation, documentation lookup, library i
 
 ## インストール
 
-Before installing this plugin, first add the [ncaq/konoka](../../README.md) marketplace to Claude Code.
+このプラグインをインストールする前に、[ncaq/konoka](../../README.md)マーケットプレイスをClaude Codeに追加してください。
 
-In Claude Code.
+Claude Codeで以下を実行します。
 
 ```text
 /plugin install research@konoka
 ```
 
-Or in project `.claude/settings.json`.
+または`.claude/settings.json`に追加します。
 
 ```json
 {


### PR DESCRIPTION
中途半端に英語が混ざっていてむしろ機械翻訳の邪魔になるかなと思ったので、
特にインストールステップなどは日本語に統一しました。
英単語レベルでは別に排除していません。
