### PR TITLE
chore: バージョンを2.0.1にリリース

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins by ncaq",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "pluginRoot": "./plugins"
   },
   "plugins": [


### PR DESCRIPTION
- マーケットプレイスのバージョンを2.0.1にリリース
- research, dependency-update-reportプラグインのMCPサーバーコンフリクト修正を含む