### PR TITLE
chore: 一部のプラグインを除きメジャーバージョン1.0.0をリリース

### DIFF
--- a/plugins/log-analyzer/.claude-plugin/plugin.json
+++ b/plugins/log-analyzer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "log-analyzer",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "description": "Extract key information from verbose command output while keeping main conversation context lean.",
   "author": {
     "name": "ncaq",

--- a/plugins/nix-tasuke/.claude-plugin/plugin.json
+++ b/plugins/nix-tasuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nix-tasuke",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Nix best practices, command patterns, and more guidance for AI coding assistants.",
   "author": {
     "name": "ncaq",

--- a/plugins/proofreading-ja/.claude-plugin/plugin.json
+++ b/plugins/proofreading-ja/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "proofreading-ja",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Fix typos, grammar, readability, and notation consistency in Japanese text. Use when the user wants to proofread or edit Japanese text.",
   "author": {
     "name": "ncaq",

--- a/plugins/research/.claude-plugin/plugin.json
+++ b/plugins/research/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "research",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "description": "Cross-source search for technical investigation, documentation lookup, library issue/PR tracking, and package information retrieval.",
   "author": {
     "name": "ncaq",


### PR DESCRIPTION
互換性をわかりやすく表現するため、
4プラグインのバージョンを1.0.0に更新しました。
`bump-cabal-index-state`と`dependency-update-report`は他スキルへの統合を検討中のため据え置きです。
