### PR TITLE
fix: context7のmcpキーを小文字に修正

### DIFF
--- a/plugins/typescript-tasuke/.claude-plugin/plugin.json
+++ b/plugins/typescript-tasuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-tasuke",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "TypeScript best practices, patterns, and guidance for AI coding assistants.",
   "author": {
     "name": "ncaq",

--- a/plugins/typescript-tasuke/.mcp.json
+++ b/plugins/typescript-tasuke/.mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "Context7": {
+    "context7": {
       "type": "http",
       "url": "https://mcp.context7.com/mcp",
       "headers": {


### PR DESCRIPTION
大文字になっていることに気が付きませんでした。
[MCP Clients - Context7 MCP](https://context7.com/docs/resources/all-clients)
を見る限り、
やはり小文字が正統派のようです。
