### PR TITLE
feat(kyosei)!: PRレビューの引数をURL形式に変更

### DIFF
--- a/plugins/kyosei/.claude-plugin/plugin.json
+++ b/plugins/kyosei/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kyosei",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Code review for PRs or local changes. Covers code quality, performance, test coverage, documentation accuracy, and security.",
   "author": {
     "name": "ncaq",

--- a/plugins/kyosei/README.md
+++ b/plugins/kyosei/README.md
@@ -71,12 +71,14 @@ PRが紐づいたブランチでも、
 
 ### ローカルからのPRレビュー(GitHub投稿モード)
 
-引数にリポジトリとPR番号を渡すと、
+引数にPRのURLを渡すと、
 CIと同様にGitHub PRへインラインコメントとして投稿します。
 
 ```
-/kyosei REPO:owner/repo PR_NUMBER:123
+/kyosei https://github.com/owner/repo/pull/123
 ```
+
+ブラウザからPRのURLをそのままコピペするだけで実行できます。
 
 外部からのPRでシークレットを渡す用意をしてない時に、
 ローカルから直接PRレビューを実行したい場合に使えます。

--- a/plugins/kyosei/README.md
+++ b/plugins/kyosei/README.md
@@ -74,8 +74,10 @@ PRが紐づいたブランチでも、
 引数にPRのURLを渡すと、
 CIと同様にGitHub PRへインラインコメントとして投稿します。
 
+例:
+
 ```
-/kyosei https://github.com/owner/repo/pull/123
+/kyosei https://github.com/ncaq/konoka/pull/42
 ```
 
 ブラウザからPRのURLをそのままコピペするだけで実行できます。

--- a/plugins/kyosei/agents/pr-conversation-collector.md
+++ b/plugins/kyosei/agents/pr-conversation-collector.md
@@ -23,13 +23,13 @@ model: sonnet
 呼び出し元からこれらの情報が渡されない場合は、
 `gh pr view --json number,url`で現在のブランチに紐づくPRの情報を取得してください。
 
-以下のコマンドを使ってPRの会話を網羅的に取得してください:
+以下のコマンドを使ってPRの会話を網羅的に取得してください。
+コマンド例の`PR_NUMBER`と`REPO`は実際のPR番号と`owner/repo`形式のリポジトリに置き換えてください(これらはシェル変数ではなく単なるプレースホルダです)。
 
 1. `gh pr view PR_NUMBER --repo REPO --json reviews,comments,latestReviews,body`でコメントと返信を取得。
 2. `mcp__github__pull_request_read`でPR情報とインラインコメントを取得。
 3. 2の方法でうまく取得できなかったり、情報が足りない場合は、
    `gh api 'repos/{owner}/{REPO}/pulls/{PR_NUMBER}/comments'`で取得。
-   変数は適宜置き換えてください。
 
 漏れがないようにしてください。
 

--- a/plugins/kyosei/agents/pr-conversation-collector.md
+++ b/plugins/kyosei/agents/pr-conversation-collector.md
@@ -24,12 +24,12 @@ model: sonnet
 `gh pr view --json number,url`で現在のブランチに紐づくPRの情報を取得してください。
 
 以下のコマンドを使ってPRの会話を網羅的に取得してください。
-コマンド例の`PR_NUMBER`と`REPO`は実際のPR番号と`owner/repo`形式のリポジトリに置き換えてください(これらはシェル変数ではなく単なるプレースホルダです)。
+コマンド例の所有者`<owner>`、リポジトリ名`<repo>`、PR番号`<pr-number>`は実際の値に置き換えてください。
 
-1. `gh pr view PR_NUMBER --repo REPO --json reviews,comments,latestReviews,body`でコメントと返信を取得。
+1. `gh pr view <pr-number> --repo <owner>/<repo> --json reviews,comments,latestReviews,body`でコメントと返信を取得。
 2. `mcp__github__pull_request_read`でPR情報とインラインコメントを取得。
 3. 2の方法でうまく取得できなかったり、情報が足りない場合は、
-   `gh api 'repos/{owner}/{REPO}/pulls/{PR_NUMBER}/comments'`で取得。
+   `gh api 'repos/<owner>/<repo>/pulls/<pr-number>/comments'`で取得。
 
 漏れがないようにしてください。
 

--- a/plugins/kyosei/skills/kyosei/SKILL.md
+++ b/plugins/kyosei/skills/kyosei/SKILL.md
@@ -17,7 +17,8 @@ allowed-tools: Bash(gh pr checks:*), Bash(gh pr diff:*), Bash(gh pr list:*), Bas
 例: `/kyosei https://github.com/ncaq/konoka/pull/42`
 
 URLから所有者`<owner>`、リポジトリ名`<repo>`、PR番号`<pr-number>`を抽出してください。
-URLが`https://github.com/<owner>/<repo>/pull/<pr-number>`を含んでいればPR URLとみなします。
+URLが`https://<host>/<owner>/<repo>/pull/<pr-number>`を含んでいればPR URLとみなします。
+ホストは`github.com`に限らずGitHub Enterpriseのドメインでも構いません。
 末尾スラッシュ、サブパス(`/files`、`/commits`等)、クエリパラメータが付いていても問題ありません。
 抽出した値は後続のコマンドで使用します。
 

--- a/plugins/kyosei/skills/kyosei/SKILL.md
+++ b/plugins/kyosei/skills/kyosei/SKILL.md
@@ -17,7 +17,8 @@ allowed-tools: Bash(gh pr checks:*), Bash(gh pr diff:*), Bash(gh pr list:*), Bas
 例: `/kyosei https://github.com/ncaq/konoka/pull/42`
 
 URLから所有者`<owner>`、リポジトリ名`<repo>`、PR番号`<pr-number>`を抽出してください。
-URLの形式は`https://github.com/<owner>/<repo>/pull/<pr-number>`です。
+URLが`https://github.com/<owner>/<repo>/pull/<pr-number>`を含んでいればPR URLとみなします。
+末尾スラッシュ、サブパス(`/files`、`/commits`等)、クエリパラメータが付いていても問題ありません。
 抽出した値は後続のコマンドで使用します。
 
 CI経由でもローカルからでも、PR URLを渡せばPRレビューモードで実行されます。

--- a/plugins/kyosei/skills/kyosei/SKILL.md
+++ b/plugins/kyosei/skills/kyosei/SKILL.md
@@ -16,8 +16,8 @@ allowed-tools: Bash(gh pr checks:*), Bash(gh pr diff:*), Bash(gh pr list:*), Bas
 
 例: `/kyosei https://github.com/ncaq/konoka/pull/42`
 
-URLからリポジトリ(`owner/repo`)とPR番号を抽出してください。
-`https://github.com/<owner>/<repo>/pull/<number>`の形式です。
+URLから所有者`<owner>`、リポジトリ名`<repo>`、PR番号`<pr-number>`を抽出してください。
+URLの形式は`https://github.com/<owner>/<repo>/pull/<pr-number>`です。
 抽出した値は後続のコマンドで使用します。
 
 CI経由でもローカルからでも、PR URLを渡せばPRレビューモードで実行されます。
@@ -37,7 +37,7 @@ CI経由でもローカルからでも、PR URLを渡せばPRレビューモー�
 
 コンテキストに応じて差分を取得します。
 
-- PRレビュー(GitHub投稿モード): `gh pr diff <pr-number> --repo <owner/repo>`(URLから抽出した値を使用)
+- PRレビュー(GitHub投稿モード): `gh pr diff <pr-number> --repo <owner>/<repo>`(URLから抽出した値を使用)
 - ローカルレビュー: `git diff <base>...HEAD` と `git log <base>...HEAD`
 
 # コードレビューの実行

--- a/plugins/kyosei/skills/kyosei/SKILL.md
+++ b/plugins/kyosei/skills/kyosei/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kyosei
 description: Code review for PRs or local changes. Covers code quality, performance, test coverage, documentation accuracy, and security. Use when reviewing PRs, checking code quality, or running comprehensive code reviews.
-argument-hint: "[REPO:owner/repo PR_NUMBER:N]"
+argument-hint: "[pr-url]"
 allowed-tools: Bash(gh pr checks:*), Bash(gh pr diff:*), Bash(gh pr list:*), Bash(gh pr view:*), Bash(gh repo view:*), Bash(git diff:*), Bash(git log:*), Bash(git rev-parse:*), Glob, Grep, Read, Task, mcp__github, mcp__github_inline_comment__create_inline_comment
 ---
 
@@ -11,16 +11,16 @@ allowed-tools: Bash(gh pr checks:*), Bash(gh pr diff:*), Bash(gh pr list:*), Bas
 
 ## PRレビュー(GitHub投稿モード)
 
-`$ARGUMENTS`が以下の形式の場合、PRレビューとして実行します。
+`$ARGUMENTS`がGitHub PRのURLの場合、PRレビューとして実行します。
 結果はGitHub PRにインラインコメントとして投稿されます。
 
-```
-REPO:owner/repo PR_NUMBER:N
-```
+例: `/kyosei https://github.com/ncaq/konoka/pull/42`
 
-例: `REPO:ncaq/konoka PR_NUMBER:42`
+URLからリポジトリ(`owner/repo`)とPR番号を抽出してください。
+`https://github.com/<owner>/<repo>/pull/<number>`の形式です。
+抽出した値は後続のコマンドで使用します。
 
-CI経由でもローカルからでも、この引数を渡せばPRレビューモードで実行されます。
+CI経由でもローカルからでも、PR URLを渡せばPRレビューモードで実行されます。
 
 ## ローカルレビュー
 
@@ -37,7 +37,7 @@ CI経由でもローカルからでも、この引数を渡せばPRレビュー�
 
 コンテキストに応じて差分を取得します。
 
-- PRレビュー(GitHub投稿モード): `gh pr diff PR_NUMBER --repo REPO`
+- PRレビュー(GitHub投稿モード): `gh pr diff <pr-number> --repo <owner/repo>`(URLから抽出した値を使用)
 - ローカルレビュー: `git diff <base>...HEAD` と `git log <base>...HEAD`
 
 # コードレビューの実行


### PR DESCRIPTION
独自の`REPO:owner/repo PR_NUMBER:N`記法を廃止し、
GitHub PRのURLをそのまま受け取る形式に変更しました。
ブラウザからPRのURLをコピペするだけでローカルからPRレビューを実行できるようになります。

`argument-hint`は`[pr-url]`に変更し、
SKILL.md内ではURLから`owner/repo`とPR番号を抽出する手順に書き換えています。 プラグインバージョンは破壊的変更のため1.0.0から2.0.0にメジャーバンプしました。

併せて`pr-conversation-collector`の手順に含まれる`PR_NUMBER`/`REPO`が、 実際の値に置き換えるプレースホルダでありシェル変数ではない旨の注釈を追加しています。
旧形式の記法と紛らわしくなるのを防ぐためです。

BREAKING CHANGE: kyoseiプラグインのPRレビュー引数がURL形式に変更されました。 旧形式`/kyosei REPO:owner/repo PR_NUMBER:N`は廃止され、
新形式`/kyosei https://github.com/owner/repo/pull/N`のみが受け付けられます。 kyosei-action側も合わせて更新する必要があります。