### PR TITLE
build: nix-templatesの最新テンプレートに合わせて設定を更新

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -36,7 +36,11 @@ indent_size = unset
 
 [*.{json,md,nix,yml,yaml}]
 # 設定やドキュメントのファイルはURLなど改行困難なものが多いため行幅制限を緩めます。
-max_line_length = 200
+max_line_length = 300
+
+[.env{,.*}]
+# 接続文字列やAPIキーなど長い設定値を含むため行幅制限を無効化します。
+max_line_length = off
 
 [*.bat]
 charset = latin1

--- a/.envrc
+++ b/.envrc
@@ -1,11 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# 存在していれば開発時に使う共有されている環境変数群を読み込みます。
+# 開発時に使う共有の環境変数を読み込みます。
+# `dotenv_if_exists`はファイルが存在しなければ何もしません。
+# deveはtypoではなく、deve, prod, stag, testと四文字に揃えた略称です。
 dotenv_if_exists .env.deve
 
-# Nix Flakesのロード。
+# Nix Flakesの開発環境をロードします。
 use flake . --accept-flake-config
 
-# 存在していればローカルなカスタムが最後に優先されるように読み込みます。
+# GitHub MCPのために各自のGitHubのTokenを取得します。
+# `GITHUB_TOKEN`にトークンを展開することは一般的に行われていることであり、
+# 危険性はほぼありません。
+# 悪意を持って環境変数にアクセスできる状況ならばどうせ基本的に`gh auth token`も起動できるはずです。
+if gh auth status &>/dev/null; then
+  GITHUB_TOKEN=$(gh auth token)
+  export GITHUB_TOKEN
+else
+  log_error "GitHub CLI is not authenticated. Please run 'gh auth login' first."
+fi
+
+# ローカル固有の環境変数を最後に読み込んで優先させます。
 dotenv_if_exists .env.local

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -26,7 +26,10 @@ runs:
       with:
         # セルフホストランナーでうっかり外部からの悪意あるPRを実行許可してしまい、
         # flake.nixの設定を受け入れると好きなキャッシュを入れられたりしてセキュリティリスクがあるため、
-        # GitHubホストランナーでのみflake.nixの設定を自動で受け入れるようにしています。
+        # GitHubホステッドランナーでのみflake.nixの設定を自動で受け入れるようにしています。
+        # GitHubホステッドランナーでは`runner.environment`は`github-hosted`になります。
+        # 仮にならなくてもキャッシュリストが読み込まれないだけなのでアクションの実行でわかるため、
+        # セキュリティのリスクはありません。
         extra_nix_config: |
           ${{ runner.environment == 'github-hosted' && 'accept-flake-config = true' || '' }}
           ${{ inputs.extra-nix-config }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       - "Type: Dependencies"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
   - package-ecosystem: npm
     directories:
       - "**/*"
@@ -16,6 +18,8 @@ updates:
       - "Type: Dependencies"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       types:
         patterns:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,13 +6,19 @@ on:
   pull_request:
   merge_group:
 
-permissions:
-  contents: read # リポジトリコンテンツの読み取り
-  id-token: write # niks3 OIDC認証
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   nix-fast-build:
+    name: nix-fast-build
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read # リポジトリコンテンツの読み取り
+      id-token: write # niks3 OIDC認証
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,14 @@ on:
     types: [completed]
     branches: [master, main]
 
-permissions:
-  contents: write # タグ作成のため
+permissions: {}
 
 jobs:
   release:
+    name: release
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write # タグ作成のため
     concurrency:
       group: release-${{ github.ref }}
       cancel-in-progress: false

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "deepwiki": {
+      "type": "http",
+      "url": "https://mcp.deepwiki.com/mcp"
+    },
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${GITHUB_TOKEN}"
+      }
+    }
+  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -107,6 +107,7 @@
                 command = pkgs.editorconfig-checker;
                 includes = [ "*" ];
               };
+              zizmor.options = [ "--pedantic" ];
             };
           };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "jiti": "^2",
         "npm-run-all2": "^8",
         "prettier": "^3",
-        "typescript": "^5.9",
+        "typescript": "^6.0.2",
         "typescript-eslint": "^8",
         "vitest": "^4"
       },
@@ -2961,9 +2961,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "jiti": "^2",
     "npm-run-all2": "^8",
     "prettier": "^3",
-    "typescript": "^5.9",
+    "typescript": "^6.0.2",
     "typescript-eslint": "^8",
     "vitest": "^4"
   },


### PR DESCRIPTION
nix-templatesのtypescriptテンプレートとの差分を解消しました。
主な変更点は以下の通りです。

- zizmorに`--pedantic`オプションを追加し、
  GitHub Actionsワークフローのセキュリティチェックを強化しました。
  これに伴い`check.yml`と`release.yml`のpermissionsをジョブレベルに移動し、
  トップレベルを`permissions: {}`に変更しています。
- `check.yml`にconcurrencyを追加して同一ブランチのCI重複実行を抑制しました。
- `.editorconfig`の設定ファイル向け`max_line_length`を200から300に変更し、
  `.env`ファイル向けセクションを追加しました。
- `.envrc`にGitHub MCPで使用する`GITHUB_TOKEN`の取得処理を追加し、
  `.mcp.json`を新規追加してdeepwikiとGitHub MCPを設定しました。
- dependabotに`cooldown: default-days: 7`を追加して更新頻度を調整しました。
- TypeScriptを5.9から6.0.2にメジャーアップデートしました。
