### PR TITLE
fix: 埋め込みコマンドをBashツール経由の実行に変更

### DIFF
--- a/plugins/kyosei/.claude-plugin/plugin.json
+++ b/plugins/kyosei/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kyosei",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Code review for PRs or local changes. Covers code quality, dependency updates, performance, test coverage, documentation accuracy, and security.",
   "author": {
     "name": "ncaq",

--- a/plugins/kyosei/skills/kyosei/SKILL.md
+++ b/plugins/kyosei/skills/kyosei/SKILL.md
@@ -8,9 +8,11 @@ allowed-tools: Bash(node:*), Glob, Grep, Read, Task, mcp__github, mcp__github_in
 # コンテキストの判定
 
 以下のコマンドでレビューコンテキストを判定します。
-結果はJSONで返されます。
+結果はJSONで返されるので、そのまま解釈してください。
 
-!`node ${CLAUDE_PLUGIN_ROOT}/dist/bin/detect-context.js $ARGUMENTS`
+```
+node ${CLAUDE_PLUGIN_ROOT}/dist/bin/detect-context.js $ARGUMENTS
+```
 
 ## JSONの解釈
 
@@ -34,9 +36,11 @@ JSONから主に以下の値を後続のコマンドで使用します:
 # 変更セットの取得
 
 以下のコマンドで変更セットを取得します。
-結果はJSONで返されます。
+結果はJSONで返されるので、そのまま解釈してください。
 
-!`node ${CLAUDE_PLUGIN_ROOT}/dist/bin/get-changeset.js $ARGUMENTS`
+```
+node ${CLAUDE_PLUGIN_ROOT}/dist/bin/get-changeset.js $ARGUMENTS
+```
 
 ## JSONの解釈
 


### PR DESCRIPTION
CI環境(claude-code-action SDK経由)で埋め込みコマンド(!コマンド)が、
エラーも出力もなく無言で失敗する問題の切り分けのため、
Bashツール経由でnodeコマンドを実行する方式に変更する。
