### PR TITLE
fix(kyosei): `baseUrl`の末尾スラッシュによるAPI 404エラーを修正

### DIFF
--- a/plugins/kyosei/.claude-plugin/plugin.json
+++ b/plugins/kyosei/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kyosei",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Code review for PRs or local changes. Covers code quality, dependency updates, performance, test coverage, documentation accuracy, and security.",
   "author": {
     "name": "ncaq",

--- a/plugins/kyosei/eslint.config.ts
+++ b/plugins/kyosei/eslint.config.ts
@@ -121,6 +121,13 @@ const config: ReturnType<typeof defineConfig> = defineConfig(
       "n/prefer-global/process": ["error", "never"],
     },
   },
+  {
+    // テストファイルではNode.js 20で実験的なFetch API(Response等)の使用を許可します。
+    files: ["test/**/*.ts"],
+    rules: {
+      "n/no-unsupported-features/node-builtins": ["error", { allowExperimental: true }],
+    },
+  },
 );
 
 // ESLintの設定をエクスポート。

--- a/plugins/kyosei/src/client.ts
+++ b/plugins/kyosei/src/client.ts
@@ -24,7 +24,7 @@ interface GitHubAuthOptions {
  * どれかがヒットすればそれで問題ないと思うので、
  * 順番はあまり重要ではないと考えています。
  */
-const tokenEnvironmentVariableNameList = [
+export const tokenEnvironmentVariableNameList = [
   "GH_ENTERPRISE_TOKEN",
   "GH_TOKEN",
   "GITHUB_API_TOKEN",

--- a/plugins/kyosei/src/client.ts
+++ b/plugins/kyosei/src/client.ts
@@ -198,7 +198,7 @@ export async function createOctokitClient(): Promise<Octokit> {
   try {
     const githubAuthOptions = await createGitHubAuthOptions();
     const githubBaseUrl = getGitHubBaseUrl();
-    // baseURLが設定されている場合はオプションに追加します。そうでない場合は空のオブジェクトを展開して何もしないようにします。
+    // baseUrlが設定されている場合はオプションに追加します。そうでない場合は空のオブジェクトを展開して何もしないようにします。
     // URL.toString()は末尾スラッシュを付けます(例: new URL("https://api.github.com").toString() → "https://api.github.com/")。
     // baseUrlとエンドポイントパスを結合する際、末尾スラッシュがあるとダブルスラッシュになり404エラーが発生します。
     const githubBaseUrlOptions = githubBaseUrl == null ? {} : { baseUrl: githubBaseUrl.toString().replace(/\/+$/, "") };

--- a/plugins/kyosei/src/client.ts
+++ b/plugins/kyosei/src/client.ts
@@ -199,8 +199,11 @@ export async function createOctokitClient(): Promise<Octokit> {
     const githubAuthOptions = await createGitHubAuthOptions();
     const githubBaseUrl = getGitHubBaseUrl();
     // baseUrlが設定されている場合はオプションに追加します。そうでない場合は空のオブジェクトを展開して何もしないようにします。
-    // URL.toString()は末尾スラッシュを付けます(例: new URL("https://api.github.com").toString() → "https://api.github.com/")。
-    // baseUrlとエンドポイントパスを結合する際、末尾スラッシュがあるとダブルスラッシュになり404エラーが発生します。
+    // `URL.toString()`はパスが空の場合末尾スラッシュを付けます。
+    // 例: `new URL("https://api.github.com").toString()` → `"https://api.github.com/"`
+    // baseUrlとエンドポイントパスを結合する際、
+    // 末尾スラッシュがあるとダブルスラッシュになり404エラーが発生するので、
+    // 末尾のスラッシュがあれば削除してからOctokitに渡すようにしています。
     const githubBaseUrlOptions = githubBaseUrl == null ? {} : { baseUrl: githubBaseUrl.toString().replace(/\/+$/, "") };
 
     return new Octokit({

--- a/plugins/kyosei/src/client.ts
+++ b/plugins/kyosei/src/client.ts
@@ -199,7 +199,9 @@ export async function createOctokitClient(): Promise<Octokit> {
     const githubAuthOptions = await createGitHubAuthOptions();
     const githubBaseUrl = getGitHubBaseUrl();
     // baseURLが設定されている場合はオプションに追加します。そうでない場合は空のオブジェクトを展開して何もしないようにします。
-    const githubBaseUrlOptions = githubBaseUrl == null ? {} : { baseUrl: githubBaseUrl.toString() };
+    // URL.toString()は末尾スラッシュを付けることがあります(例: new URL("https://api.github.com").toString() → "https://api.github.com/")。
+    // Octokitはurl = baseUrl + urlと単純に結合するため、末尾スラッシュがあるとダブルスラッシュになり404エラーが発生します。
+    const githubBaseUrlOptions = githubBaseUrl == null ? {} : { baseUrl: githubBaseUrl.toString().replace(/\/+$/, "") };
 
     return new Octokit({
       auth: githubAuthOptions.token,

--- a/plugins/kyosei/src/client.ts
+++ b/plugins/kyosei/src/client.ts
@@ -199,8 +199,8 @@ export async function createOctokitClient(): Promise<Octokit> {
     const githubAuthOptions = await createGitHubAuthOptions();
     const githubBaseUrl = getGitHubBaseUrl();
     // baseURLが設定されている場合はオプションに追加します。そうでない場合は空のオブジェクトを展開して何もしないようにします。
-    // URL.toString()は末尾スラッシュを付けることがあります(例: new URL("https://api.github.com").toString() → "https://api.github.com/")。
-    // Octokitはurl = baseUrl + urlと単純に結合するため、末尾スラッシュがあるとダブルスラッシュになり404エラーが発生します。
+    // URL.toString()は末尾スラッシュを付けます(例: new URL("https://api.github.com").toString() → "https://api.github.com/")。
+    // baseUrlとエンドポイントパスを結合する際、末尾スラッシュがあるとダブルスラッシュになり404エラーが発生します。
     const githubBaseUrlOptions = githubBaseUrl == null ? {} : { baseUrl: githubBaseUrl.toString().replace(/\/+$/, "") };
 
     return new Octokit({

--- a/plugins/kyosei/test/client.test.ts
+++ b/plugins/kyosei/test/client.test.ts
@@ -1,6 +1,6 @@
 import process from "node:process";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { createOctokitClient } from "../src/client.js";
+import { createOctokitClient, tokenEnvironmentVariableNameList } from "../src/client.js";
 
 /**
  * テスト中に環境変数を差し替えるヘルパー。
@@ -31,19 +31,7 @@ function withEnv(overrides: Record<string, string | undefined>): () => void {
 describe("createOctokitClient", () => {
   // GitHub ActionsのCI環境で設定される典型的な環境変数をテスト前にクリアして、
   // テスト後に復元します。
-  const envKeysToClean = [
-    "GH_ENTERPRISE_TOKEN",
-    "GH_HOST",
-    "GH_TOKEN",
-    "GITHUB_API_TOKEN",
-    "GITHUB_API_URL",
-    "GITHUB_ENTERPRISE_TOKEN",
-    "GITHUB_PAT",
-    "GITHUB_PERSONAL_ACCESS_TOKEN",
-    "GITHUB_SERVER_URL",
-    "GITHUB_TOKEN",
-    "INPUT_GITHUB_TOKEN",
-  ];
+  const envKeysToClean = [...tokenEnvironmentVariableNameList, "GH_HOST", "GITHUB_API_URL", "GITHUB_SERVER_URL"];
 
   let restoreEnv: () => void;
 

--- a/plugins/kyosei/test/client.test.ts
+++ b/plugins/kyosei/test/client.test.ts
@@ -4,7 +4,7 @@ import { createOctokitClient, tokenEnvironmentVariableNameList } from "../src/cl
 
 /**
  * テスト中に環境変数を差し替えるヘルパー。
- * 元の値を保存して、afterEachで復元します。
+ * 元の値を保存し、返却されたクリーンアップ関数を呼ぶことで復元します。
  */
 function withEnv(overrides: Record<string, string | undefined>): () => void {
   const saved: Record<string, string | undefined> = {};

--- a/plugins/kyosei/test/client.test.ts
+++ b/plugins/kyosei/test/client.test.ts
@@ -113,7 +113,7 @@ describe("createOctokitClient", () => {
           const url = new URL(urlString);
           expect(url.origin).toBe(expectedOrigin);
           if (expectedPathPrefix != null) {
-            expect(url.pathname).toMatch(new RegExp(`^${expectedPathPrefix}`));
+            expect(url.pathname).toSatisfy((p: string) => p.startsWith(expectedPathPrefix));
           }
         }
       } finally {

--- a/plugins/kyosei/test/client.test.ts
+++ b/plugins/kyosei/test/client.test.ts
@@ -1,5 +1,5 @@
 import process from "node:process";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { createOctokitClient, tokenEnvironmentVariableNameList } from "../src/client.js";
 
 /**
@@ -33,19 +33,16 @@ describe("createOctokitClient", () => {
   // テスト後に復元します。
   const envKeysToClean = [...tokenEnvironmentVariableNameList, "GH_HOST", "GITHUB_API_URL", "GITHUB_SERVER_URL"];
 
-  let restoreEnv: () => void;
-
   beforeEach(() => {
     const overrides: Record<string, undefined> = {};
     for (const key of envKeysToClean) {
       overrides[key] = undefined;
     }
-    restoreEnv = withEnv(overrides);
-  });
-
-  afterEach(() => {
-    restoreEnv();
-    vi.restoreAllMocks();
+    const restoreEnv = withEnv(overrides);
+    return () => {
+      restoreEnv();
+      vi.restoreAllMocks();
+    };
   });
 
   describe("baseUrlの末尾スラッシュによるダブルスラッシュの防止", () => {

--- a/plugins/kyosei/test/client.test.ts
+++ b/plugins/kyosei/test/client.test.ts
@@ -1,3 +1,4 @@
+import process from "node:process";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { createOctokitClient } from "../src/client.js";
 

--- a/plugins/kyosei/test/client.test.ts
+++ b/plugins/kyosei/test/client.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { createOctokitClient } from "../src/client.js";
+
+/**
+ * テスト中に環境変数を差し替えるヘルパー。
+ * 元の値を保存して、afterEachで復元します。
+ */
+function withEnv(overrides: Record<string, string | undefined>): () => void {
+  const saved: Record<string, string | undefined> = {};
+  for (const key of Object.keys(overrides)) {
+    saved[key] = process.env[key];
+    const value = overrides[key];
+    if (value == null) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  return () => {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value == null) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  };
+}
+
+describe("createOctokitClient", () => {
+  // GitHub ActionsのCI環境で設定される典型的な環境変数をテスト前にクリアして、
+  // テスト後に復元します。
+  const envKeysToClean = [
+    "GH_ENTERPRISE_TOKEN",
+    "GH_HOST",
+    "GH_TOKEN",
+    "GITHUB_API_TOKEN",
+    "GITHUB_API_URL",
+    "GITHUB_ENTERPRISE_TOKEN",
+    "GITHUB_PAT",
+    "GITHUB_PERSONAL_ACCESS_TOKEN",
+    "GITHUB_SERVER_URL",
+    "GITHUB_TOKEN",
+    "INPUT_GITHUB_TOKEN",
+  ];
+
+  let restoreEnv: () => void;
+
+  beforeEach(() => {
+    const overrides: Record<string, undefined> = {};
+    for (const key of envKeysToClean) {
+      overrides[key] = undefined;
+    }
+    restoreEnv = withEnv(overrides);
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    vi.restoreAllMocks();
+  });
+
+  describe("baseUrlの末尾スラッシュによるダブルスラッシュの防止", () => {
+    test("GITHUB_API_URLが設定されている場合、APIリクエストのURLにダブルスラッシュが含まれない", async () => {
+      // GitHub Actionsでは GITHUB_API_URL=https://api.github.com が設定される。
+      // URL.toString()は末尾スラッシュを付けるため、
+      // そのままOctokitに渡すとダブルスラッシュのURLが生成されて404になる。
+      const restore = withEnv({
+        GITHUB_TOKEN: "ghp_test_token",
+        GITHUB_API_URL: "https://api.github.com",
+      });
+      try {
+        const requestedUrls: string[] = [];
+        const mockFetch = vi.fn().mockImplementation((url: string | URL) => {
+          requestedUrls.push(url.toString());
+          return Promise.resolve(
+            new Response(JSON.stringify({ default_branch: "main" }), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            }),
+          );
+        });
+        vi.stubGlobal("fetch", mockFetch);
+
+        const octokit = await createOctokitClient();
+        await octokit.rest.repos.get({ owner: "test-owner", repo: "test-repo" });
+
+        expect(requestedUrls.length).toBeGreaterThan(0);
+        for (const url of requestedUrls) {
+          // プロトコル部分(https://)の後にダブルスラッシュがないことを確認します。
+          const afterProtocol = url.replace(/^https?:\/\//, "");
+          expect(afterProtocol).not.toContain("//");
+        }
+      } finally {
+        restore();
+      }
+    });
+
+    test("GITHUB_SERVER_URLが設定されている場合、APIリクエストのURLにダブルスラッシュが含まれない", async () => {
+      const restore = withEnv({
+        GITHUB_TOKEN: "ghp_test_token",
+        GITHUB_SERVER_URL: "https://github.com",
+      });
+      try {
+        const requestedUrls: string[] = [];
+        const mockFetch = vi.fn().mockImplementation((url: string | URL) => {
+          requestedUrls.push(url.toString());
+          return Promise.resolve(
+            new Response(JSON.stringify({ default_branch: "main" }), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            }),
+          );
+        });
+        vi.stubGlobal("fetch", mockFetch);
+
+        const octokit = await createOctokitClient();
+        await octokit.rest.repos.get({ owner: "test-owner", repo: "test-repo" });
+
+        expect(requestedUrls.length).toBeGreaterThan(0);
+        for (const url of requestedUrls) {
+          const afterProtocol = url.replace(/^https?:\/\//, "");
+          expect(afterProtocol).not.toContain("//");
+        }
+      } finally {
+        restore();
+      }
+    });
+
+    test("GitHub Enterpriseの場合もAPIリクエストのURLにダブルスラッシュが含まれない", async () => {
+      const restore = withEnv({
+        GITHUB_TOKEN: "ghp_test_token",
+        GITHUB_API_URL: "https://ghe.example.com/api/v3",
+      });
+      try {
+        const requestedUrls: string[] = [];
+        const mockFetch = vi.fn().mockImplementation((url: string | URL) => {
+          requestedUrls.push(url.toString());
+          return Promise.resolve(
+            new Response(JSON.stringify({ default_branch: "main" }), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            }),
+          );
+        });
+        vi.stubGlobal("fetch", mockFetch);
+
+        const octokit = await createOctokitClient();
+        await octokit.rest.repos.get({ owner: "test-owner", repo: "test-repo" });
+
+        expect(requestedUrls.length).toBeGreaterThan(0);
+        for (const url of requestedUrls) {
+          const afterProtocol = url.replace(/^https?:\/\//, "");
+          expect(afterProtocol).not.toContain("//");
+        }
+      } finally {
+        restore();
+      }
+    });
+  });
+});

--- a/plugins/kyosei/test/client.test.ts
+++ b/plugins/kyosei/test/client.test.ts
@@ -45,27 +45,97 @@ describe("createOctokitClient", () => {
     };
   });
 
+  /**
+   * fetchをモックして、リクエストされたURLを記録するヘルパー。
+   * 返されたURL配列を検証に使います。
+   */
+  function mockFetchAndCaptureUrls(): string[] {
+    const requestedUrls: string[] = [];
+    const mockFetch = vi.fn().mockImplementation((url: string | URL) => {
+      requestedUrls.push(url.toString());
+      return Promise.resolve(
+        new Response(JSON.stringify({ default_branch: "main" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    });
+    vi.stubGlobal("fetch", mockFetch);
+    return requestedUrls;
+  }
+
+  // getGitHubBaseUrlはexportされていないため、
+  // createOctokitClient経由でfetchのリクエスト先URLを検証することで間接的にテストしています。
+  describe("getGitHubBaseUrlの解決", () => {
+    test.each([
+      {
+        label: "GITHUB_API_URLが直接指定",
+        env: { GITHUB_API_URL: "https://api.github.com" },
+        expectedOrigin: "https://api.github.com",
+      },
+      {
+        label: "GITHUB_SERVER_URLがgithub.com",
+        env: { GITHUB_SERVER_URL: "https://github.com" },
+        expectedOrigin: "https://api.github.com",
+      },
+      {
+        label: "GITHUB_SERVER_URLがGHE",
+        env: { GITHUB_SERVER_URL: "https://ghe.example.com" },
+        expectedOrigin: "https://ghe.example.com",
+        expectedPathPrefix: "/api/v3",
+      },
+      {
+        label: "GH_HOSTがgithub.com",
+        env: { GH_HOST: "github.com" },
+        expectedOrigin: "https://api.github.com",
+      },
+      {
+        label: "GH_HOSTがGHE",
+        env: { GH_HOST: "ghe.example.com" },
+        expectedOrigin: "https://ghe.example.com",
+        expectedPathPrefix: "/api/v3",
+      },
+      {
+        label: "何も設定なし(デフォルト)",
+        env: {},
+        expectedOrigin: "https://api.github.com",
+      },
+    ])("$labelの場合、$expectedOriginにリクエストが送られる", async ({ env, expectedOrigin, expectedPathPrefix }) => {
+      const restore = withEnv({ GITHUB_TOKEN: "ghp_test_token", ...env });
+      try {
+        const requestedUrls = mockFetchAndCaptureUrls();
+
+        const octokit = await createOctokitClient();
+        await octokit.rest.repos.get({ owner: "test-owner", repo: "test-repo" });
+
+        expect(requestedUrls.length).toBeGreaterThan(0);
+        for (const urlString of requestedUrls) {
+          const url = new URL(urlString);
+          expect(url.origin).toBe(expectedOrigin);
+          if (expectedPathPrefix != null) {
+            expect(url.pathname).toMatch(new RegExp(`^${expectedPathPrefix}`));
+          }
+        }
+      } finally {
+        restore();
+      }
+    });
+  });
+
   // URL.toString()は末尾スラッシュを付けるため、
   // そのままOctokitに渡すとダブルスラッシュのURLが生成されて404になる。
   describe("baseUrlの末尾スラッシュによるダブルスラッシュの防止", () => {
     test.each([
       { label: "GITHUB_API_URL", env: { GITHUB_API_URL: "https://api.github.com" } },
-      { label: "GITHUB_SERVER_URL", env: { GITHUB_SERVER_URL: "https://github.com" } },
-      { label: "GitHub Enterprise", env: { GITHUB_API_URL: "https://ghe.example.com/api/v3" } },
+      { label: "GITHUB_SERVER_URL(github.com)", env: { GITHUB_SERVER_URL: "https://github.com" } },
+      { label: "GITHUB_SERVER_URL(GHE)", env: { GITHUB_SERVER_URL: "https://ghe.example.com" } },
+      { label: "GH_HOST(github.com)", env: { GH_HOST: "github.com" } },
+      { label: "GH_HOST(GHE)", env: { GH_HOST: "ghe.example.com" } },
+      { label: "デフォルト", env: {} },
     ])("$labelが設定されている場合、APIリクエストのURLにダブルスラッシュが含まれない", async ({ env }) => {
       const restore = withEnv({ GITHUB_TOKEN: "ghp_test_token", ...env });
       try {
-        const requestedUrls: string[] = [];
-        const mockFetch = vi.fn().mockImplementation((url: string | URL) => {
-          requestedUrls.push(url.toString());
-          return Promise.resolve(
-            new Response(JSON.stringify({ default_branch: "main" }), {
-              status: 200,
-              headers: { "content-type": "application/json" },
-            }),
-          );
-        });
-        vi.stubGlobal("fetch", mockFetch);
+        const requestedUrls = mockFetchAndCaptureUrls();
 
         const octokit = await createOctokitClient();
         await octokit.rest.repos.get({ owner: "test-owner", repo: "test-repo" });

--- a/plugins/kyosei/test/client.test.ts
+++ b/plugins/kyosei/test/client.test.ts
@@ -132,7 +132,7 @@ describe("createOctokitClient", () => {
       { label: "GH_HOST(github.com)", env: { GH_HOST: "github.com" } },
       { label: "GH_HOST(GHE)", env: { GH_HOST: "ghe.example.com" } },
       { label: "デフォルト", env: {} },
-    ])("$labelが設定されている場合、APIリクエストのURLにダブルスラッシュが含まれない", async ({ env }) => {
+    ])("$labelの場合、APIリクエストのURLにダブルスラッシュが含まれない", async ({ env }) => {
       const restore = withEnv({ GITHUB_TOKEN: "ghp_test_token", ...env });
       try {
         const requestedUrls = mockFetchAndCaptureUrls();

--- a/plugins/kyosei/test/client.test.ts
+++ b/plugins/kyosei/test/client.test.ts
@@ -45,15 +45,15 @@ describe("createOctokitClient", () => {
     };
   });
 
+  // URL.toString()は末尾スラッシュを付けるため、
+  // そのままOctokitに渡すとダブルスラッシュのURLが生成されて404になる。
   describe("baseUrlの末尾スラッシュによるダブルスラッシュの防止", () => {
-    test("GITHUB_API_URLが設定されている場合、APIリクエストのURLにダブルスラッシュが含まれない", async () => {
-      // GitHub Actionsでは GITHUB_API_URL=https://api.github.com が設定される。
-      // URL.toString()は末尾スラッシュを付けるため、
-      // そのままOctokitに渡すとダブルスラッシュのURLが生成されて404になる。
-      const restore = withEnv({
-        GITHUB_TOKEN: "ghp_test_token",
-        GITHUB_API_URL: "https://api.github.com",
-      });
+    test.each([
+      { label: "GITHUB_API_URL", env: { GITHUB_API_URL: "https://api.github.com" } },
+      { label: "GITHUB_SERVER_URL", env: { GITHUB_SERVER_URL: "https://github.com" } },
+      { label: "GitHub Enterprise", env: { GITHUB_API_URL: "https://ghe.example.com/api/v3" } },
+    ])("$labelが設定されている場合、APIリクエストのURLにダブルスラッシュが含まれない", async ({ env }) => {
+      const restore = withEnv({ GITHUB_TOKEN: "ghp_test_token", ...env });
       try {
         const requestedUrls: string[] = [];
         const mockFetch = vi.fn().mockImplementation((url: string | URL) => {
@@ -73,68 +73,6 @@ describe("createOctokitClient", () => {
         expect(requestedUrls.length).toBeGreaterThan(0);
         for (const url of requestedUrls) {
           // プロトコル部分(https://)の後にダブルスラッシュがないことを確認します。
-          const afterProtocol = url.replace(/^https?:\/\//, "");
-          expect(afterProtocol).not.toContain("//");
-        }
-      } finally {
-        restore();
-      }
-    });
-
-    test("GITHUB_SERVER_URLが設定されている場合、APIリクエストのURLにダブルスラッシュが含まれない", async () => {
-      const restore = withEnv({
-        GITHUB_TOKEN: "ghp_test_token",
-        GITHUB_SERVER_URL: "https://github.com",
-      });
-      try {
-        const requestedUrls: string[] = [];
-        const mockFetch = vi.fn().mockImplementation((url: string | URL) => {
-          requestedUrls.push(url.toString());
-          return Promise.resolve(
-            new Response(JSON.stringify({ default_branch: "main" }), {
-              status: 200,
-              headers: { "content-type": "application/json" },
-            }),
-          );
-        });
-        vi.stubGlobal("fetch", mockFetch);
-
-        const octokit = await createOctokitClient();
-        await octokit.rest.repos.get({ owner: "test-owner", repo: "test-repo" });
-
-        expect(requestedUrls.length).toBeGreaterThan(0);
-        for (const url of requestedUrls) {
-          const afterProtocol = url.replace(/^https?:\/\//, "");
-          expect(afterProtocol).not.toContain("//");
-        }
-      } finally {
-        restore();
-      }
-    });
-
-    test("GitHub Enterpriseの場合もAPIリクエストのURLにダブルスラッシュが含まれない", async () => {
-      const restore = withEnv({
-        GITHUB_TOKEN: "ghp_test_token",
-        GITHUB_API_URL: "https://ghe.example.com/api/v3",
-      });
-      try {
-        const requestedUrls: string[] = [];
-        const mockFetch = vi.fn().mockImplementation((url: string | URL) => {
-          requestedUrls.push(url.toString());
-          return Promise.resolve(
-            new Response(JSON.stringify({ default_branch: "main" }), {
-              status: 200,
-              headers: { "content-type": "application/json" },
-            }),
-          );
-        });
-        vi.stubGlobal("fetch", mockFetch);
-
-        const octokit = await createOctokitClient();
-        await octokit.rest.repos.get({ owner: "test-owner", repo: "test-repo" });
-
-        expect(requestedUrls.length).toBeGreaterThan(0);
-        for (const url of requestedUrls) {
           const afterProtocol = url.replace(/^https?:\/\//, "");
           expect(afterProtocol).not.toContain("//");
         }


### PR DESCRIPTION
`URL.toString()`が末尾スラッシュを付けるため、
Octokitが`baseUrl + url`を単純に結合した結果、
ダブルスラッシュのURL(例: `https://api.github.com//repos/...`)が生成され、 GitHub APIが404を返していました。
GitHub Actionsでは`GITHUB_API_URL`が設定されるためCI環境で必ず発生します。

close #139