### PR TITLE
test: vitestのreporterをverboseに変更してTUI問題を解消

### DIFF
--- a/plugins/commit/package.json
+++ b/plugins/commit/package.json
@@ -10,7 +10,7 @@
     "lint:eslint": "eslint .",
     "lint:prettier": "prettier --check .",
     "lint:tsc": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run --reporter=verbose"
   },
   "devDependencies": {
     "@eslint/compat": "2.0.5",

--- a/plugins/kyosei/package.json
+++ b/plugins/kyosei/package.json
@@ -11,7 +11,7 @@
     "lint:eslint": "eslint .",
     "lint:prettier": "prettier --check .",
     "lint:tsc": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run --reporter=verbose"
   },
   "dependencies": {
     "git-url-parse": "^16.1.0",


### PR DESCRIPTION
Claude Codeからnix-fast-build経由でvitestを実行すると、
デフォルトのreporterがインタラクティブなTUI出力を行うため表示が崩れていました。
`--reporter=verbose`を指定してプレーンテキスト出力に切り替えました。

close #147
