### PR TITLE
fix(research): surveyエージェントの直接起動を抑制するようdescriptionを改善

### DIFF
--- a/plugins/research/.claude-plugin/plugin.json
+++ b/plugins/research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "research",
-  "version": "1.1.0",
-  "description": "Cross-source search for technical investigation, documentation lookup, library issue/PR tracking, and package information retrieval.",
+  "version": "1.1.1",
+  "description": "Cross-source research via parallel survey agents. Use when the user asks to research or investigate.",
   "author": {
     "name": "ncaq",
     "email": "ncaq@ncaq.net",
@@ -10,5 +10,5 @@
   "homepage": "https://github.com/ncaq/konoka/tree/master/plugins/research",
   "repository": "https://github.com/ncaq/konoka",
   "license": "Apache-2.0",
-  "keywords": ["research", "search", "documentation"]
+  "keywords": ["research", "search", "survey"]
 }

--- a/plugins/research/README.md
+++ b/plugins/research/README.md
@@ -2,7 +2,7 @@
 
 Cross-source research via parallel survey agents. Use when the user asks to research or investigate.
 
-複数の情報ソースを横断検索して技術調査を行うClaude Codeプラグインです。
+並列surveyエージェントを活用して複数の情報ソースを横断的に調査するClaude Codeプラグインです。
 
 ## インストール
 

--- a/plugins/research/README.md
+++ b/plugins/research/README.md
@@ -1,6 +1,6 @@
 # research
 
-Cross-source search for technical investigation, documentation lookup, library issue/PR tracking, and package information retrieval.
+Cross-source research via parallel survey agents. Use when the user asks to research or investigate.
 
 複数の情報ソースを横断検索して技術調査を行うClaude Codeプラグインです。
 

--- a/plugins/research/agents/survey.md
+++ b/plugins/research/agents/survey.md
@@ -1,6 +1,6 @@
 ---
 name: survey
-description: Cross-source search for technical investigation, documentation lookup, library issue/PR tracking, and package information retrieval.
+description: Internal agent for the research skill. Do NOT call this agent directly — use the /research skill instead, which orchestrates parallel survey agents for efficient cross-source search.
 tools:
   - Glob
   - Grep

--- a/plugins/research/skills/research/SKILL.md
+++ b/plugins/research/skills/research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research
-description: Cross-source search for technical investigation, documentation lookup, library issue/PR tracking, and package information retrieval. Use when the user asks to research, investigate, or look up technical topics across multiple sources.
+description: Cross-source research via parallel survey agents. documentation lookup, library issue/PR tracking, and package information retrieval. Use when the user asks to research or investigate.
 argument-hint: "query"
 context: fork
 agent: general-purpose

--- a/plugins/research/skills/research/SKILL.md
+++ b/plugins/research/skills/research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research
-description: Cross-source research via parallel survey agents. documentation lookup, library issue/PR tracking, and package information retrieval. Use when the user asks to research or investigate.
+description: Cross-source research via parallel survey agents. Use when the user asks to research or investigate.
 argument-hint: "query"
 context: fork
 agent: general-purpose


### PR DESCRIPTION
surveyエージェントがスキルを経由せず直接起動されることが多かったため、
エージェント側に内部用である旨を明記し、
スキル側のdescriptionも簡潔に整理しました。
