### PR TITLE
refactor(kyosei): エージェントのGitHub MCPツールを読み取り専用に限定

### DIFF
--- a/plugins/kyosei/.claude-plugin/plugin.json
+++ b/plugins/kyosei/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kyosei",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Code review for PRs or local changes. Covers code quality, dependency updates, performance, test coverage, documentation accuracy, and security.",
   "author": {
     "name": "ncaq",

--- a/plugins/kyosei/agents/code-quality-reviewer.md
+++ b/plugins/kyosei/agents/code-quality-reviewer.md
@@ -14,7 +14,14 @@ tools:
   - Read
   - WebFetch
   - WebSearch
-  - mcp__github
+  - mcp__github__get_file_contents
+  - mcp__github__issue_read
+  - mcp__github__pull_request_read
+  - mcp__github__list_commits
+  - mcp__github__list_pull_requests
+  - mcp__github__search_code
+  - mcp__github__search_issues
+  - mcp__github__search_pull_requests
 model: inherit
 ---
 

--- a/plugins/kyosei/agents/dependency-update-reviewer.md
+++ b/plugins/kyosei/agents/dependency-update-reviewer.md
@@ -13,7 +13,19 @@ tools:
   - Skill(research)
   - WebFetch
   - WebSearch
-  - mcp__github
+  - mcp__github__get_file_contents
+  - mcp__github__get_latest_release
+  - mcp__github__get_release_by_tag
+  - mcp__github__get_tag
+  - mcp__github__issue_read
+  - mcp__github__pull_request_read
+  - mcp__github__list_commits
+  - mcp__github__list_pull_requests
+  - mcp__github__list_releases
+  - mcp__github__list_tags
+  - mcp__github__search_code
+  - mcp__github__search_issues
+  - mcp__github__search_pull_requests
 model: inherit
 ---
 

--- a/plugins/kyosei/agents/documentation-accuracy-reviewer.md
+++ b/plugins/kyosei/agents/documentation-accuracy-reviewer.md
@@ -13,7 +13,14 @@ tools:
   - Read
   - WebFetch
   - WebSearch
-  - mcp__github
+  - mcp__github__get_file_contents
+  - mcp__github__issue_read
+  - mcp__github__pull_request_read
+  - mcp__github__list_commits
+  - mcp__github__list_pull_requests
+  - mcp__github__search_code
+  - mcp__github__search_issues
+  - mcp__github__search_pull_requests
 model: inherit
 ---
 

--- a/plugins/kyosei/agents/performance-reviewer.md
+++ b/plugins/kyosei/agents/performance-reviewer.md
@@ -15,7 +15,14 @@ tools:
   - Read
   - WebFetch
   - WebSearch
-  - mcp__github
+  - mcp__github__get_file_contents
+  - mcp__github__issue_read
+  - mcp__github__pull_request_read
+  - mcp__github__list_commits
+  - mcp__github__list_pull_requests
+  - mcp__github__search_code
+  - mcp__github__search_issues
+  - mcp__github__search_pull_requests
 model: inherit
 ---
 

--- a/plugins/kyosei/agents/pr-conversation-collector.md
+++ b/plugins/kyosei/agents/pr-conversation-collector.md
@@ -9,7 +9,9 @@ tools:
   - Bash(gh api *pulls/*/comments*)
   - Bash(gh api *pulls/*/reviews*)
   - Bash(gh pr view:*)
-  - mcp__github
+  - mcp__github__issue_read
+  - mcp__github__pull_request_read
+  - mcp__github__list_pull_requests
 model: sonnet
 ---
 

--- a/plugins/kyosei/agents/security-code-reviewer.md
+++ b/plugins/kyosei/agents/security-code-reviewer.md
@@ -16,7 +16,14 @@ tools:
   - Read
   - WebFetch
   - WebSearch
-  - mcp__github
+  - mcp__github__get_file_contents
+  - mcp__github__issue_read
+  - mcp__github__pull_request_read
+  - mcp__github__list_commits
+  - mcp__github__list_pull_requests
+  - mcp__github__search_code
+  - mcp__github__search_issues
+  - mcp__github__search_pull_requests
 model: inherit
 ---
 

--- a/plugins/kyosei/agents/test-coverage-reviewer.md
+++ b/plugins/kyosei/agents/test-coverage-reviewer.md
@@ -13,7 +13,14 @@ tools:
   - Read
   - WebFetch
   - WebSearch
-  - mcp__github
+  - mcp__github__get_file_contents
+  - mcp__github__issue_read
+  - mcp__github__pull_request_read
+  - mcp__github__list_commits
+  - mcp__github__list_pull_requests
+  - mcp__github__search_code
+  - mcp__github__search_issues
+  - mcp__github__search_pull_requests
 model: inherit
 ---
 


### PR DESCRIPTION
`mcp__github`のワイルドカード指定を個別の読み取り専用ツール名に置き換えました。
書き込み系ツールへのアクセスを防止して誤動作を防ぐとともに、
エージェントにMCPツールの存在を明示してGitHub CLIへの不要なフォールバックを抑制します。
dependency-update-reviewerにはリリース・タグ関連ツールを追加し、
pr-conversation-collectorはPR会話収集に必要な最小限のツールに絞りました。
