### PR TITLE
feat(kyosei)!: GitHubのレビュー本文にレベルとタグを含めるように変更

### DIFF
--- a/plugins/kyosei/.claude-plugin/plugin.json
+++ b/plugins/kyosei/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kyosei",
-  "version": "2.5.0",
+  "version": "3.0.0",
   "description": "Code review for PRs or local changes. Covers code quality, dependency updates, performance, test coverage, documentation accuracy, and security.",
   "author": {
     "name": "ncaq",

--- a/plugins/kyosei/README.md
+++ b/plugins/kyosei/README.md
@@ -109,16 +109,16 @@ PRがopenされるか更新されると自動でレビューが実行され、
 
 ## サブエージェント
 
-| エージェント                    | 観点                                       |
-| ------------------------------- | ------------------------------------------ |
-| code-quality-reviewer           | コード品質、命名、DRY原則、SOLID原則       |
-| dependency-update-reviewer      | 依存関係の更新内容とプロジェクトへの影響   |
-| documentation-accuracy-reviewer | ドキュメントと実装の整合性                 |
-| performance-reviewer            | アルゴリズム計算量、N+1問題、メモリリーク  |
-| security-code-reviewer          | OWASP Top 10、インジェクション、認証/認可  |
-| test-coverage-reviewer          | テストカバレッジ、テスト品質、欠落シナリオ |
+| エージェント           | 観点                                       |
+| ---------------------- | ------------------------------------------ |
+| code-quality-reviewer  | コード品質、命名、DRY原則、SOLID原則       |
+| dependency-reviewer    | 依存関係の変更内容とプロジェクトへの影響   |
+| documentation-reviewer | ドキュメントと実装の整合性                 |
+| performance-reviewer   | アルゴリズム計算量、N+1問題、メモリリーク  |
+| security-reviewer      | OWASP Top 10、インジェクション、認証/認可  |
+| test-reviewer          | テストカバレッジ、テスト品質、欠落シナリオ |
 
-dependency-update-reviewerは差分に依存関係の変更が含まれている場合に、
+dependency-reviewerは差分に依存関係の変更が含まれている場合に、
 リリースノートやコミュニティの反応を調査して影響を評価します。
 [research@konoka](../research/)プラグインが利用可能な場合は`/research`スキルを活用し、
 利用できない場合は直接Web検索やMCPで調査します。

--- a/plugins/kyosei/agents/code-quality-reviewer.md
+++ b/plugins/kyosei/agents/code-quality-reviewer.md
@@ -77,7 +77,8 @@ Markdownのコードブロック記法も付けないでください。
     "path": "src/example.ts",
     "line": 42,
     "body": "問題の説明と具体的な改善案",
-    "level": "high"
+    "tags": ["code-quality"],
+    "level": "WARNING"
   }
 ]
 ```
@@ -87,12 +88,13 @@ Markdownのコードブロック記法も付けないでください。
 - `path`: ファイルの相対パス
 - `line`: 該当行番号
 - `body`: 問題の説明と推奨される改善案をまとめた文章
+- `tags`: `["code-quality"]`
 - `level`: 以下のいずれか
-  - `"critical"`
-  - `"high"`
-  - `"medium"`
-  - `"low"`
-  - `"info"`
+  - `"CAUTION"`
+  - `"WARNING"`
+  - `"IMPORTANT"`
+  - `"TIP"`
+  - `"NOTE"`
 
 複数行にまたがる指摘の場合は`startLine`(開始行)を追加してください。
 差分の削除行に対する指摘の場合は`"side": "LEFT"`を追加してください。

--- a/plugins/kyosei/agents/dependency-reviewer.md
+++ b/plugins/kyosei/agents/dependency-reviewer.md
@@ -1,8 +1,8 @@
 ---
-name: dependency-update-reviewer
+name: dependency-reviewer
 description: |
-  Review dependency updates for changes and impact.
-  Use when analyzing PR dependency version bumps.
+  Review dependency changes and impact.
+  Use when analyzing PR dependency additions, removals, and version changes.
 tools:
   - Bash(git diff:*)
   - Bash(git log:*)
@@ -29,10 +29,10 @@ tools:
 model: inherit
 ---
 
-差分に含まれる依存関係の更新を調査し、
+差分に含まれる依存関係の変更を調査し、
 その内容とプロジェクトへの影響を評価してください。
 
-まず差分に依存関係の更新が含まれているか確認してください。
+まず差分に依存関係の変更が含まれているか確認してください。
 含まれていない場合は、
 依存関係の変更なしと報告して即座に終了してください。
 以降の調査は不要です。
@@ -44,10 +44,10 @@ model: inherit
 # 依存関係の変更の特定
 
 - ロックファイルやマニフェストファイルの変更から、
-  どの依存関係がどのバージョンからどのバージョンに更新されたかを特定する
+  どの依存関係が追加、削除、更新されたかを特定する
 - 新規追加された依存関係を特定する
 - 削除された依存関係を特定する
-- メジャー、マイナー、パッチのどの種類の更新かを分類する
+- 更新された依存関係については、メジャー、マイナー、パッチのどの種類の更新かを分類する
 
 # 変更内容の調査
 
@@ -59,7 +59,7 @@ model: inherit
 
 # プロジェクトへの影響の評価
 
-- 更新された依存関係がプロジェクトのコードベースでどのように使われているかを確認する
+- 変更された依存関係がプロジェクトのコードベースでどのように使われているかを確認する
 - 破壊的変更がプロジェクトに影響するかを評価する
 - 非推奨になったAPIをプロジェクトが使用していないか確認する
 - 間接的な依存関係への影響を評価する
@@ -80,7 +80,8 @@ Markdownのコードブロック記法も付けないでください。
     "path": "src/example.ts",
     "line": 42,
     "body": "問題の説明と具体的な改善案",
-    "level": "high"
+    "tags": ["dependency"],
+    "level": "WARNING"
   }
 ]
 ```
@@ -90,16 +91,17 @@ Markdownのコードブロック記法も付けないでください。
 - `path`: ファイルの相対パス
 - `line`: 該当行番号
 - `body`: 問題の説明と推奨される改善案をまとめた文章
+- `tags`: `["dependency"]`
 - `level`: 以下のいずれか
-  - `"critical"`
-  - `"high"`
-  - `"medium"`
-  - `"low"`
-  - `"info"`
+  - `"CAUTION"`
+  - `"WARNING"`
+  - `"IMPORTANT"`
+  - `"TIP"`
+  - `"NOTE"`
 
 複数行にまたがる指摘の場合は`startLine`(開始行)を追加してください。
 差分の削除行に対する指摘の場合は`"side": "LEFT"`を追加してください。
 
-依存関係の更新があるが問題が見つからない場合は、
-更新内容の概要を`"info"`レベルの要素として報告してください。
+依存関係の変更があるが問題が見つからない場合は、
+変更内容の概要を`"NOTE"`レベルの要素として報告してください。
 依存関係の変更自体がない場合は空配列`[]`を返してください。

--- a/plugins/kyosei/agents/documentation-reviewer.md
+++ b/plugins/kyosei/agents/documentation-reviewer.md
@@ -1,5 +1,5 @@
 ---
-name: documentation-accuracy-reviewer
+name: documentation-reviewer
 description: |
   Use this agent when you need to verify that code documentation is accurate, complete, and up-to-date.
   Use this agent after:
@@ -82,7 +82,8 @@ Markdownのコードブロック記法も付けないでください。
     "path": "src/example.ts",
     "line": 42,
     "body": "問題の説明と具体的な改善案",
-    "level": "high"
+    "tags": ["documentation"],
+    "level": "WARNING"
   }
 ]
 ```
@@ -92,12 +93,13 @@ Markdownのコードブロック記法も付けないでください。
 - `path`: ファイルの相対パス
 - `line`: 該当行番号
 - `body`: 問題の説明と推奨される改善案をまとめた文章
+- `tags`: `["documentation"]`
 - `level`: 以下のいずれか
-  - `"critical"`
-  - `"high"`
-  - `"medium"`
-  - `"low"`
-  - `"info"`
+  - `"CAUTION"`
+  - `"WARNING"`
+  - `"IMPORTANT"`
+  - `"TIP"`
+  - `"NOTE"`
 
 複数行にまたがる指摘の場合は`startLine`(開始行)を追加してください。
 差分の削除行に対する指摘の場合は`"side": "LEFT"`を追加してください。

--- a/plugins/kyosei/agents/performance-reviewer.md
+++ b/plugins/kyosei/agents/performance-reviewer.md
@@ -81,7 +81,8 @@ Markdownのコードブロック記法も付けないでください。
     "path": "src/example.ts",
     "line": 42,
     "body": "問題の説明と具体的な改善案",
-    "level": "high"
+    "tags": ["performance"],
+    "level": "WARNING"
   }
 ]
 ```
@@ -91,12 +92,13 @@ Markdownのコードブロック記法も付けないでください。
 - `path`: ファイルの相対パス
 - `line`: 該当行番号
 - `body`: 問題の説明と推奨される改善案をまとめた文章(推定される計算量やリソース使用量を含む)
+- `tags`: `["performance"]`
 - `level`: 以下のいずれか
-  - `"critical"`
-  - `"high"`
-  - `"medium"`
-  - `"low"`
-  - `"info"`
+  - `"CAUTION"`
+  - `"WARNING"`
+  - `"IMPORTANT"`
+  - `"TIP"`
+  - `"NOTE"`
 
 複数行にまたがる指摘の場合は`startLine`(開始行)を追加してください。
 差分の削除行に対する指摘の場合は`"side": "LEFT"`を追加してください。

--- a/plugins/kyosei/agents/security-reviewer.md
+++ b/plugins/kyosei/agents/security-reviewer.md
@@ -1,5 +1,5 @@
 ---
-name: security-code-reviewer
+name: security-reviewer
 description: |
   Use this agent when you need to review code for security vulnerabilities,
   input validation issues, or authentication/authorization flaws.
@@ -102,7 +102,8 @@ Markdownのコードブロック記法も付けないでください。
     "path": "src/example.ts",
     "line": 42,
     "body": "問題の説明と具体的な改善案",
-    "level": "high"
+    "tags": ["security"],
+    "level": "WARNING"
   }
 ]
 ```
@@ -112,12 +113,13 @@ Markdownのコードブロック記法も付けないでください。
 - `path`: ファイルの相対パス
 - `line`: 該当行番号
 - `body`: 問題の説明と推奨される改善案をまとめた文章(関連するCWE番号があれば含む)
+- `tags`: `["security"]`
 - `level`: 以下のいずれか
-  - `"critical"`
-  - `"high"`
-  - `"medium"`
-  - `"low"`
-  - `"info"`
+  - `"CAUTION"`
+  - `"WARNING"`
+  - `"IMPORTANT"`
+  - `"TIP"`
+  - `"NOTE"`
 
 複数行にまたがる指摘の場合は`startLine`(開始行)を追加してください。
 差分の削除行に対する指摘の場合は`"side": "LEFT"`を追加してください。

--- a/plugins/kyosei/agents/test-reviewer.md
+++ b/plugins/kyosei/agents/test-reviewer.md
@@ -1,5 +1,5 @@
 ---
-name: test-coverage-reviewer
+name: test-reviewer
 description: |
   Use this agent when you need to review testing implementation and coverage.
   Examples:
@@ -72,7 +72,8 @@ Markdownのコードブロック記法も付けないでください。
     "path": "src/example.ts",
     "line": 42,
     "body": "問題の説明と具体的な改善案",
-    "level": "high"
+    "tags": ["test"],
+    "level": "WARNING"
   }
 ]
 ```
@@ -82,12 +83,13 @@ Markdownのコードブロック記法も付けないでください。
 - `path`: ファイルの相対パス
 - `line`: 該当行番号
 - `body`: 問題の説明と推奨される改善案をまとめた文章
+- `tags`: `["test"]`
 - `level`: 以下のいずれか
-  - `"critical"`
-  - `"high"`
-  - `"medium"`
-  - `"low"`
-  - `"info"`
+  - `"CAUTION"`
+  - `"WARNING"`
+  - `"IMPORTANT"`
+  - `"TIP"`
+  - `"NOTE"`
 
 複数行にまたがる指摘の場合は`startLine`(開始行)を追加してください。
 差分の削除行に対する指摘の場合は`"side": "LEFT"`を追加してください。

--- a/plugins/kyosei/skills/kyosei/SKILL.md
+++ b/plugins/kyosei/skills/kyosei/SKILL.md
@@ -76,11 +76,11 @@ PRが特定できない場合はフィールド自体が省略されます。
 主要領域について以下の専門のサブエージェントを並列で使用して包括的なコードレビューを実行します。
 
 - [code-quality-reviewer](../../agents/code-quality-reviewer.md)
-- [dependency-update-reviewer](../../agents/dependency-update-reviewer.md)
-- [documentation-accuracy-reviewer](../../agents/documentation-accuracy-reviewer.md)
+- [dependency-reviewer](../../agents/dependency-reviewer.md)
+- [documentation-reviewer](../../agents/documentation-reviewer.md)
 - [performance-reviewer](../../agents/performance-reviewer.md)
-- [security-code-reviewer](../../agents/security-code-reviewer.md)
-- [test-coverage-reviewer](../../agents/test-coverage-reviewer.md)
+- [security-reviewer](../../agents/security-reviewer.md)
+- [test-reviewer](../../agents/test-reviewer.md)
 
 サブエージェントは一度に全て並列に起動してください。
 
@@ -105,7 +105,8 @@ PRが特定できない場合はフィールド自体が省略されます。
 
 統合時のルール:
 
-- `level`が異なる場合: より高い重大度を採用する
+- `level`が異なる場合: `CAUTION`, `WARNING`, `IMPORTANT`, `TIP`, `NOTE`の順でより高い重大度を採用する
+- `tags`が異なる場合: 両方のタグを重複なく含める
 - `body`が異なる場合: 両方の固有の情報を含めてマージする
 - `line`がずれている場合: より正確な行を採用する
 
@@ -144,14 +145,23 @@ PRが特定できない場合はフィールド自体が省略されます。
   - `line`: コメントを付ける行番号(複数行の場合は終了行)
   - `startLine`: 複数行コメントの開始行(省略可能で省略したときはsingle line)
   - `side`: `"LEFT"`(削除行)または`"RIGHT"`(追加行)。デフォルト`"RIGHT"`
+  - `tags`: 指摘のタグ配列。以下の文字列を必要なだけ指定してください。該当タグがない場合は空配列にしてください。
+    - `"code-quality"`
+    - `"dependency"`
+    - `"documentation"`
+    - `"performance"`
+    - `"security"`
+    - `"test"`
   - `level`: 指摘の重大度。以下のいずれか。
-    - `"critical"`
-    - `"high"`
-    - `"medium"`
-    - `"low"`
-    - `"info"`
+    - `"CAUTION"`
+    - `"WARNING"`
+    - `"IMPORTANT"`
+    - `"TIP"`
+    - `"NOTE"`
 
-レビュー本文とインラインコメントは1回のAPI呼び出しで一括投稿されます。
+レビュー本文とインラインコメントは1回のプログラム呼び出しで一括投稿されます。
+インラインコメントの本文には`level`に対応するGitHub Alertと、
+`tags`に対応する絵文字付きラベルがプログラムによって自動付与されます。
 
 ### eventの決定
 
@@ -168,22 +178,22 @@ PRが特定できない場合はフィールド自体が省略されます。
 
 以下のいずれかに該当する場合。
 
-- 今回のコメントに`critical`レベルの指摘がある。
+- 今回のコメントに`CAUTION`レベルの指摘がある。
 - 前回のレビューの`state`が`CHANGES_REQUESTED`で、その指摘に対応する修正が確認できない。
 
 #### `APPROVE`
 
 以下の全てを満たす場合。
 
-- 今回のコメントが`low`または`info`のみ、もしくはコメントなし。
-- 前回のレビューでの`low`または`info`以外の指摘が全て対応済みであること。
+- 今回のコメントが`TIP`または`NOTE`のみ、もしくはコメントなし。
+- 前回のレビューでの`TIP`または`NOTE`以外の指摘が全て対応済みであること。
 
 #### `COMMENT`
 
 上記のいずれにも該当しない場合。
 
-例として`high`や`medium`の指摘があるだけの場合。
-`high`でも`REQUEST_CHANGES`ではないのは直感に反するかもしれませんが、
+例として`WARNING`や`IMPORTANT`の指摘があるだけの場合。
+`WARNING`でも`REQUEST_CHANGES`ではないのは直感に反するかもしれませんが、
 あまり機械によるレビューが厳しすぎないようにするための措置です。
 
 ### 投稿

--- a/plugins/kyosei/src/submit-review.ts
+++ b/plugins/kyosei/src/submit-review.ts
@@ -8,7 +8,16 @@ import type { Octokit } from "octokit";
 
 const DiffSideSchema = Schema.Literal("LEFT", "RIGHT");
 
-const ReviewLevelSchema = Schema.Literal("critical", "high", "medium", "low", "info");
+const ReviewLevelSchema = Schema.Literal("CAUTION", "WARNING", "IMPORTANT", "TIP", "NOTE");
+
+const ReviewTagSchema = Schema.Literal(
+  "code-quality",
+  "dependency",
+  "documentation",
+  "performance",
+  "security",
+  "test",
+);
 
 const ReviewCommentSchema = Schema.Struct({
   path: Schema.NonEmptyString,
@@ -17,6 +26,7 @@ const ReviewCommentSchema = Schema.Struct({
   startLine: Schema.optionalWith(Schema.Number.pipe(Schema.int(), Schema.positive()), { exact: true }),
   side: Schema.optionalWith(DiffSideSchema, { exact: true }),
   level: ReviewLevelSchema,
+  tags: Schema.Array(ReviewTagSchema),
 });
 
 const ReviewEventSchema = Schema.Literal("APPROVE", "COMMENT", "REQUEST_CHANGES");
@@ -39,6 +49,25 @@ type ReviewSubmission = typeof ReviewSubmissionSchema.Type;
 interface ReviewSubmissionResult {
   readonly reviewId: number;
   readonly htmlUrl: string;
+}
+
+const reviewTagLabel: Record<typeof ReviewTagSchema.Type, string> = {
+  "code-quality": "🧹 Code Quality",
+  dependency: "📦 Dependency",
+  documentation: "📚 Documentation",
+  performance: "⚡ Performance",
+  security: "🔒 Security",
+  test: "🧪 Test",
+};
+
+function quoteAlertLine(line: string): string {
+  return `> ${line}`;
+}
+
+function formatReviewCommentBody(comment: typeof ReviewCommentSchema.Type): string {
+  const tagLabel =
+    comment.tags.length > 0 ? `${quoteAlertLine(comment.tags.map((tag) => reviewTagLabel[tag]).join(" "))}\n` : "";
+  return `> [!${comment.level}]\n${tagLabel}\n${comment.body}`;
 }
 
 /**
@@ -66,7 +95,7 @@ export async function submitReview(octokit: Octokit, submission: ReviewSubmissio
     comments:
       submission.comments?.map((c) => ({
         path: c.path,
-        body: c.body,
+        body: formatReviewCommentBody(c),
         line: c.line,
         side: c.side ?? "RIGHT",
         ...(c.startLine != null ? { start_line: c.startLine, start_side: c.side ?? "RIGHT" } : {}),

--- a/plugins/kyosei/test/submit-review.test.ts
+++ b/plugins/kyosei/test/submit-review.test.ts
@@ -34,7 +34,8 @@ describe("decodeReviewSubmission", () => {
           path: "src/foo.ts",
           body: "fix this",
           line: 10,
-          level: "high",
+          level: "WARNING",
+          tags: ["code-quality"],
         },
         {
           path: "src/bar.ts",
@@ -42,7 +43,8 @@ describe("decodeReviewSubmission", () => {
           line: 20,
           startLine: 15,
           side: "LEFT",
-          level: "low",
+          level: "TIP",
+          tags: ["test"],
         },
       ],
     };
@@ -53,6 +55,7 @@ describe("decodeReviewSubmission", () => {
     expect(submission.comments).toHaveLength(2);
     expect(submission.comments?.[0]?.path).toBe("src/foo.ts");
     expect(submission.comments?.[0]?.side).toBeUndefined();
+    expect(submission.comments?.[0]?.tags).toEqual(["code-quality"]);
     expect(submission.comments?.[1]?.startLine).toBe(15);
     expect(submission.comments?.[1]?.side).toBe("LEFT");
   });
@@ -88,7 +91,7 @@ describe("decodeReviewSubmission", () => {
   test("コメントのlineが0の場合はエラーになる", () => {
     const input = {
       ...validInput,
-      comments: [{ path: "a.ts", body: "x", line: 0, level: "info" }],
+      comments: [{ path: "a.ts", body: "x", line: 0, level: "NOTE", tags: [] }],
     };
     expect(() => decodeReviewSubmission(JSON.stringify(input))).toThrow();
   });
@@ -96,7 +99,7 @@ describe("decodeReviewSubmission", () => {
   test("コメントのpathが空文字の場合はエラーになる", () => {
     const input = {
       ...validInput,
-      comments: [{ path: "", body: "x", line: 1, level: "info" }],
+      comments: [{ path: "", body: "x", line: 1, level: "NOTE", tags: [] }],
     };
     expect(() => decodeReviewSubmission(JSON.stringify(input))).toThrow();
   });
@@ -104,7 +107,23 @@ describe("decodeReviewSubmission", () => {
   test("不正なlevelはエラーになる", () => {
     const input = {
       ...validInput,
-      comments: [{ path: "a.ts", body: "x", line: 1, level: "unknown" }],
+      comments: [{ path: "a.ts", body: "x", line: 1, level: "unknown", tags: [] }],
+    };
+    expect(() => decodeReviewSubmission(JSON.stringify(input))).toThrow();
+  });
+
+  test("不正なtagはエラーになる", () => {
+    const input = {
+      ...validInput,
+      comments: [{ path: "a.ts", body: "x", line: 1, level: "NOTE", tags: ["unknown"] }],
+    };
+    expect(() => decodeReviewSubmission(JSON.stringify(input))).toThrow();
+  });
+
+  test("コメントのtagsが欠落している場合はエラーになる", () => {
+    const input = {
+      ...validInput,
+      comments: [{ path: "a.ts", body: "x", line: 1, level: "NOTE" }],
     };
     expect(() => decodeReviewSubmission(JSON.stringify(input))).toThrow();
   });
@@ -121,7 +140,7 @@ describe("decodeReviewSubmission", () => {
   test("不正なsideはエラーになる", () => {
     const input = {
       ...validInput,
-      comments: [{ path: "a.ts", body: "x", line: 1, level: "info", side: "CENTER" }],
+      comments: [{ path: "a.ts", body: "x", line: 1, level: "NOTE", tags: [], side: "CENTER" }],
     };
     expect(() => decodeReviewSubmission(JSON.stringify(input))).toThrow();
   });
@@ -134,7 +153,7 @@ describe("decodeReviewSubmission", () => {
   test("コメントに未知のプロパティがある場合はエラーになる", () => {
     const input = {
       ...validInput,
-      comments: [{ path: "a.ts", body: "x", line: 1, level: "info", unknownField: "unexpected" }],
+      comments: [{ path: "a.ts", body: "x", line: 1, level: "NOTE", tags: [], unknownField: "unexpected" }],
     };
     expect(() => decodeReviewSubmission(JSON.stringify(input))).toThrow();
   });
@@ -191,7 +210,7 @@ describe("submitReview", () => {
     const octokit = createMockOctokit();
     const input = {
       ...validInput,
-      comments: [{ path: "src/foo.ts", body: "fix", line: 42, level: "medium" }],
+      comments: [{ path: "src/foo.ts", body: "fix", line: 42, level: "IMPORTANT", tags: ["code-quality"] }],
     };
     const submission = decodeReviewSubmission(JSON.stringify(input));
     await submitReview(octokit, submission);
@@ -200,17 +219,58 @@ describe("submitReview", () => {
     const comment = call?.comments?.[0];
     expect(comment).toEqual({
       path: "src/foo.ts",
-      body: "fix",
+      body: "> [!IMPORTANT]\n> 🧹 Code Quality\n\nfix",
       line: 42,
       side: "RIGHT",
     });
+  });
+
+  test("tagsが空配列ならタグラベルを出力しない", async () => {
+    const octokit = createMockOctokit();
+    const input = {
+      ...validInput,
+      comments: [{ path: "src/foo.ts", body: "fix", line: 42, level: "IMPORTANT", tags: [] }],
+    };
+    const submission = decodeReviewSubmission(JSON.stringify(input));
+    await submitReview(octokit, submission);
+
+    const call = vi.mocked(octokit.rest.pulls.createReview).mock.calls[0]?.[0];
+    expect(call?.comments?.[0]?.body).toBe("> [!IMPORTANT]\n\nfix");
+  });
+
+  test("複数tagをコメント本文に含められる", async () => {
+    const octokit = createMockOctokit();
+    const input = {
+      ...validInput,
+      comments: [{ path: "src/foo.ts", body: "fix", line: 42, level: "IMPORTANT", tags: ["security", "performance"] }],
+    };
+    const submission = decodeReviewSubmission(JSON.stringify(input));
+    await submitReview(octokit, submission);
+
+    const call = vi.mocked(octokit.rest.pulls.createReview).mock.calls[0]?.[0];
+    expect(call?.comments?.[0]?.body).toBe("> [!IMPORTANT]\n> 🔒 Security ⚡ Performance\n\nfix");
+  });
+
+  test("複数行コメントもGitHub Alert内に収まる", async () => {
+    const octokit = createMockOctokit();
+    const input = {
+      ...validInput,
+      comments: [{ path: "src/foo.ts", body: "line 1\n\nline 3", line: 42, level: "CAUTION", tags: ["security"] }],
+    };
+    const submission = decodeReviewSubmission(JSON.stringify(input));
+    await submitReview(octokit, submission);
+
+    const call = vi.mocked(octokit.rest.pulls.createReview).mock.calls[0]?.[0];
+    expect(call?.comments?.[0]?.body).toBe("> [!CAUTION]\n> 🔒 Security\n\nline 1\n\nline 3");
   });
 
   test("multi-lineコメントのパラメータが正しく変換される", async () => {
     const octokit = createMockOctokit();
     const input = {
       ...validInput,
-      comments: [{ path: "src/bar.ts", body: "refactor", line: 20, startLine: 10, side: "LEFT", level: "low" }],
+      comments: [
+        { path: "src/bar.ts", body: "refactor", line: 20, startLine: 10, side: "LEFT", level: "TIP", tags: ["test"] },
+      ],
     };
     const submission = decodeReviewSubmission(JSON.stringify(input));
     await submitReview(octokit, submission);
@@ -219,7 +279,7 @@ describe("submitReview", () => {
     const comment = call?.comments?.[0];
     expect(comment).toEqual({
       path: "src/bar.ts",
-      body: "refactor",
+      body: "> [!TIP]\n> 🧪 Test\n\nrefactor",
       line: 20,
       start_line: 10,
       side: "LEFT",
@@ -231,14 +291,14 @@ describe("submitReview", () => {
     const octokit = createMockOctokit();
     const input = {
       ...validInput,
-      comments: [{ path: "src/foo.ts", body: "x", line: 20, startLine: 10, level: "low" }],
+      comments: [{ path: "src/foo.ts", body: "x", line: 20, startLine: 10, level: "TIP", tags: ["test"] }],
     };
     const submission = decodeReviewSubmission(JSON.stringify(input));
     await submitReview(octokit, submission);
     const call = vi.mocked(octokit.rest.pulls.createReview).mock.calls[0]?.[0];
     expect(call?.comments?.[0]).toEqual({
       path: "src/foo.ts",
-      body: "x",
+      body: "> [!TIP]\n> 🧪 Test\n\nx",
       line: 20,
       start_line: 10,
       side: "RIGHT",


### PR DESCRIPTION
合わせてエージェントの名前も実態に合わせて汎用的なものに変更しました。
コメントのレベルは内部的にもGitHubのアラートに対応させています。

BREAKING CHANGE:
レビューコメントの表示形式が変更されて、
レベルがアラートで表示され、
タグが付与されます。

close #167
