### PR TITLE
feat: effortレベルの調整

### DIFF
--- a/plugins/kyosei/.claude-plugin/plugin.json
+++ b/plugins/kyosei/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kyosei",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Code review for PRs or local changes. Covers code quality, dependency updates, performance, test coverage, documentation accuracy, and security.",
   "author": {
     "name": "ncaq",

--- a/plugins/kyosei/agents/code-quality-reviewer.md
+++ b/plugins/kyosei/agents/code-quality-reviewer.md
@@ -23,6 +23,7 @@ tools:
   - mcp__github__search_issues
   - mcp__github__search_pull_requests
 model: inherit
+effort: high
 ---
 
 あなたはソフトウェアエンジニアリングのベストプラクティス、

--- a/plugins/kyosei/agents/dependency-reviewer.md
+++ b/plugins/kyosei/agents/dependency-reviewer.md
@@ -27,6 +27,7 @@ tools:
   - mcp__github__search_issues
   - mcp__github__search_pull_requests
 model: inherit
+effort: high
 ---
 
 差分に含まれる依存関係の変更を調査し、

--- a/plugins/kyosei/agents/documentation-reviewer.md
+++ b/plugins/kyosei/agents/documentation-reviewer.md
@@ -22,6 +22,7 @@ tools:
   - mcp__github__search_issues
   - mcp__github__search_pull_requests
 model: inherit
+effort: high
 ---
 
 あなたはコードドキュメント標準、

--- a/plugins/kyosei/agents/performance-reviewer.md
+++ b/plugins/kyosei/agents/performance-reviewer.md
@@ -24,6 +24,7 @@ tools:
   - mcp__github__search_issues
   - mcp__github__search_pull_requests
 model: inherit
+effort: high
 ---
 
 あなたはソフトウェアシステムの全レイヤーにわたるパフォーマンスボトルネックの特定と解決に深い専門知識を持つ、

--- a/plugins/kyosei/agents/security-reviewer.md
+++ b/plugins/kyosei/agents/security-reviewer.md
@@ -25,6 +25,7 @@ tools:
   - mcp__github__search_issues
   - mcp__github__search_pull_requests
 model: inherit
+effort: high
 ---
 
 あなたはアプリケーションセキュリティ、

--- a/plugins/kyosei/agents/test-reviewer.md
+++ b/plugins/kyosei/agents/test-reviewer.md
@@ -22,6 +22,7 @@ tools:
   - mcp__github__search_issues
   - mcp__github__search_pull_requests
 model: inherit
+effort: high
 ---
 
 あなたはテスト駆動開発、

--- a/plugins/kyosei/skills/kyosei/SKILL.md
+++ b/plugins/kyosei/skills/kyosei/SKILL.md
@@ -3,6 +3,9 @@ name: kyosei
 description: Code review for PRs or local changes. Covers code quality, dependency updates, performance, test coverage, documentation accuracy, and security. Use when reviewing PRs, checking code quality, or running comprehensive code reviews.
 argument-hint: "[pr-url]"
 allowed-tools: Bash(node:*), Glob, Grep, Read, Task, mcp__github
+context: fork
+agent: general-purpose
+effort: medium
 ---
 
 # get-review-infoでの情報の取得


### PR DESCRIPTION
コストの観点からeffortレベルを全体的に引き下げることにしました。
kyoseiスキル自体は各エージェントを操作してJSONを投稿するだけなので、
mediumで十分と判断しました。
各エージェントは実際にコードレビューを行うため、
highを設定しています。
