### PR TITLE
refactor: eslintの`@typescript-eslint/no-inferrable-types`を復活

### DIFF
--- a/plugins/kyosei/eslint.config.ts
+++ b/plugins/kyosei/eslint.config.ts
@@ -75,8 +75,6 @@ const config: ReturnType<typeof defineConfig> = defineConfig(
           allowIIFEs: true, // 即時実行関数の型を持ってもあまり意味がないので要求しません。
         },
       ],
-      // `--isolatedDeclarations`と互換性がないので無効化します。
-      "@typescript-eslint/no-inferrable-types": "off",
     },
   },
   {

--- a/plugins/kyosei/tsconfig.json
+++ b/plugins/kyosei/tsconfig.json
@@ -9,6 +9,7 @@
     "verbatimModuleSyntax": true,
     "isolatedModules": true,
     "noEmit": true,
+    "isolatedDeclarations": false,
     "erasableSyntaxOnly": true,
     "strict": true,
     "exactOptionalPropertyTypes": true,


### PR DESCRIPTION
型推論との兼ね合いで`--isolatedDeclarations`を削除したので、
互換性がないから無効化していいたルールを復活させました。
またnix-templatesの方では`--isolatedDeclarations`を削除ではなく`false`にしているので、
そちらに合わせました。
