### PR TITLE
feat(kyosei): submit-reviewに`--dry-run`を追加

### DIFF
--- a/plugins/kyosei/.claude-plugin/plugin.json
+++ b/plugins/kyosei/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kyosei",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Code review for PRs or local changes. Covers code quality, dependency updates, performance, test coverage, documentation accuracy, and security.",
   "author": {
     "name": "ncaq",

--- a/plugins/kyosei/bin/submit-review.ts
+++ b/plugins/kyosei/bin/submit-review.ts
@@ -4,19 +4,30 @@
  */
 
 import process from "node:process";
-import { Args, Command } from "@effect/cli";
+import { Args, Command, Options } from "@effect/cli";
 import { NodeContext, NodeRuntime } from "@effect/platform-node";
 import { Console, Effect } from "effect";
 import { createOctokitClient } from "../src/client";
-import { decodeReviewSubmission, submitReview } from "../src/submit-review";
+import { decodeReviewSubmission, previewReview, submitReview } from "../src/submit-review";
+
+const dryRun = Options.boolean("dry-run").pipe(
+  Options.withDescription(
+    "投稿せずに、組み立て済みのcreateReviewパラメータをJSON出力します。スキーマ検証とメタデータフッター生成は実行されます。",
+  ),
+);
 
 const json = Args.text({ name: "json" }).pipe(
   Args.withDescription("レビュー投稿用のJSON文字列(ReviewSubmissionSchemaに準拠)。"),
 );
 
-const command = Command.make("submit-review", { json }, ({ json }) =>
+const command = Command.make("submit-review", { dryRun, json }, ({ dryRun, json }) =>
   Effect.gen(function* () {
     const submission = decodeReviewSubmission(json);
+    if (dryRun) {
+      const params = yield* previewReview(submission);
+      yield* Console.log(JSON.stringify({ dryRun: true, params }));
+      return;
+    }
     const octokit = yield* createOctokitClient();
     const submissionResult = yield* submitReview(octokit, submission);
     yield* Console.log(JSON.stringify(submissionResult));

--- a/plugins/kyosei/skills/kyosei/SKILL.md
+++ b/plugins/kyosei/skills/kyosei/SKILL.md
@@ -235,6 +235,20 @@ node ${CLAUDE_PLUGIN_ROOT}/dist/bin/submit-review.js 'JSON_STRING'
 本文は空にできないため、
 簡潔な総評を記述してください。
 
+### 動作確認(`--dry-run`)
+
+組み立てたJSONがスキーマやメタデータ生成を通るかだけ検証したい場合は、
+`--dry-run`フラグを付けて実行します。
+
+```bash
+node ${CLAUDE_PLUGIN_ROOT}/dist/bin/submit-review.js --dry-run 'JSON_STRING'
+```
+
+GitHub APIへの投稿は行われず、
+`{"dryRun": true, "params": {...}}`の形式で、
+`createReview`に渡される予定のパラメータがJSON出力されます。
+通常のレビューワークフローでは使いません。
+
 ## ローカル出力の場合
 
 各フィードバックは以下の形式で出力します:

--- a/plugins/kyosei/src/submit-review.ts
+++ b/plugins/kyosei/src/submit-review.ts
@@ -41,6 +41,32 @@ export function decodeReviewSubmission(input: string): typeof ReviewSubmissionSc
   return Schema.decodeUnknownSync(Schema.parseJson(ReviewSubmissionSchema), { onExcessProperty: "error" })(input);
 }
 
+/** `octokit.rest.pulls.createReview`に渡すパラメータ型。 */
+export type CreateReviewParams = NonNullable<Parameters<Octokit["rest"]["pulls"]["createReview"]>[0]>;
+
+/**
+ * `submission`とメタデータ付与済みの`body`から、`octokit.rest.pulls.createReview`へ渡すパラメータを組み立てます。
+ * API呼び出しは行いません。`submitReview`と`previewReview`の双方で共有されます。
+ */
+function buildCreateReviewParams(submission: typeof ReviewSubmissionSchema.Type, body: string): CreateReviewParams {
+  return {
+    owner: submission.owner,
+    repo: submission.repo,
+    pull_number: submission.prNumber,
+    commit_id: submission.headCommitId,
+    event: submission.event,
+    body,
+    comments:
+      submission.comments?.map((c) => ({
+        path: c.path,
+        body: formatReviewCommentBody(c),
+        line: c.line,
+        side: c.side ?? "RIGHT",
+        ...(c.startLine != null ? { start_line: c.startLine, start_side: c.side ?? "RIGHT" } : {}),
+      })) ?? [],
+  };
+}
+
 /**
  * PRレビューを投稿します。
  * `octokit.rest.pulls.createReview`を使い、
@@ -53,27 +79,25 @@ export function submitReview(
 ): Effect.Effect<typeof ReviewSubmissionResultSchema.Type, Error, CommandExecutor.CommandExecutor> {
   return Effect.gen(function* () {
     const body = yield* mkBodyAppendMetadata(submission);
-    const response = yield* Effect.tryPromise(() =>
-      octokit.rest.pulls.createReview({
-        owner: submission.owner,
-        repo: submission.repo,
-        pull_number: submission.prNumber,
-        commit_id: submission.headCommitId,
-        event: submission.event,
-        body,
-        comments:
-          submission.comments?.map((c) => ({
-            path: c.path,
-            body: formatReviewCommentBody(c),
-            line: c.line,
-            side: c.side ?? "RIGHT",
-            ...(c.startLine != null ? { start_line: c.startLine, start_side: c.side ?? "RIGHT" } : {}),
-          })) ?? [],
-      }),
-    );
+    const params = buildCreateReviewParams(submission, body);
+    const response = yield* Effect.tryPromise(() => octokit.rest.pulls.createReview(params));
     return {
       reviewId: response.data.id,
       htmlUrl: new URL(response.data.html_url),
     };
+  });
+}
+
+/**
+ * 投稿はせずに、`submitReview`が`octokit.rest.pulls.createReview`へ渡すであろうパラメータを組み立てて返します。
+ * 入力スキーマの検証(`decodeReviewSubmission`)とメタデータフッター生成(`mkBodyAppendMetadata`)を実走するため、
+ * パイプライン全体の動作確認に使えます。
+ */
+export function previewReview(
+  submission: typeof ReviewSubmissionSchema.Type,
+): Effect.Effect<CreateReviewParams, never, CommandExecutor.CommandExecutor> {
+  return Effect.gen(function* () {
+    const body = yield* mkBodyAppendMetadata(submission);
+    return buildCreateReviewParams(submission, body);
   });
 }

--- a/plugins/kyosei/test/submit-review.test.ts
+++ b/plugins/kyosei/test/submit-review.test.ts
@@ -2,7 +2,7 @@ import { it } from "@effect/vitest";
 import { Effect } from "effect";
 import type { Octokit } from "octokit";
 import { describe, expect, test, vi } from "vitest";
-import { decodeReviewSubmission, submitReview } from "../src/submit-review";
+import { decodeReviewSubmission, previewReview, submitReview } from "../src/submit-review";
 import { fakeCommandExecutor } from "./fake-command";
 
 const claudeFakeLayer = fakeCommandExecutor(() => Effect.fail(new Error("claude not installed in test environment")));
@@ -349,6 +349,90 @@ describe("submitReview", () => {
         expect(submissionResult.htmlUrl).toEqual(
           new URL("https://github.com/test-owner/test-repo/pull/42#pullrequestreview-999"),
         );
+      }),
+    );
+  });
+});
+
+describe("previewReview", () => {
+  it.layer(claudeFakeLayer)((it) => {
+    it.effect("createReviewが呼ばれない", () =>
+      Effect.gen(function* () {
+        const createReview = vi.fn();
+        const octokit = { rest: { pulls: { createReview } } } as unknown as Octokit;
+        const submission = decodeReviewSubmission(JSON.stringify(validInput));
+        yield* previewReview(submission);
+
+        expect(createReview).not.toHaveBeenCalled();
+        // 念のため、Octokitの中身を全く触らないことを保証するため呼び出し回数で確認。
+        expect(octokit.rest.pulls.createReview).not.toHaveBeenCalled();
+      }),
+    );
+
+    it.effect("組み立て済みパラメータに必須フィールドが正しく入る", () =>
+      Effect.gen(function* () {
+        const submission = decodeReviewSubmission(
+          JSON.stringify({ ...validInput, event: "REQUEST_CHANGES", headCommitId: "abc1234" }),
+        );
+        const params = yield* previewReview(submission);
+
+        expect(params.owner).toBe("test-owner");
+        expect(params.repo).toBe("test-repo");
+        expect(params.pull_number).toBe(42);
+        expect(params.commit_id).toBe("abc1234");
+        expect(params.event).toBe("REQUEST_CHANGES");
+        expect(params.body?.startsWith("review body")).toBe(true);
+      }),
+    );
+
+    it.effect("bodyにメタデータフッターが付与されている", () =>
+      Effect.gen(function* () {
+        const submission = decodeReviewSubmission(JSON.stringify(validInput));
+        const params = yield* previewReview(submission);
+
+        expect(params.body ?? "").toContain("<details>");
+      }),
+    );
+
+    it.effect("インラインコメントが`submitReview`と同じく変換される", () =>
+      Effect.gen(function* () {
+        const submission = decodeReviewSubmission(
+          JSON.stringify({
+            ...validInput,
+            comments: [
+              {
+                path: "src/bar.ts",
+                body: "refactor",
+                line: 20,
+                startLine: 10,
+                side: "LEFT",
+                level: "TIP",
+                tags: ["test"],
+              },
+            ],
+          }),
+        );
+        const params = yield* previewReview(submission);
+
+        expect(params.comments).toEqual([
+          {
+            path: "src/bar.ts",
+            body: "> [!TIP]\n> 🧪 Test\n\nrefactor",
+            line: 20,
+            start_line: 10,
+            side: "LEFT",
+            start_side: "LEFT",
+          },
+        ]);
+      }),
+    );
+
+    it.effect("commentsを省略するとparamsのcommentsは空配列になる", () =>
+      Effect.gen(function* () {
+        const submission = decodeReviewSubmission(JSON.stringify(validInput));
+        const params = yield* previewReview(submission);
+
+        expect(params.comments).toEqual([]);
       }),
     );
   });


### PR DESCRIPTION
スキーマ検証やメタデータフッター生成が通るかだけを動作確認したい場合に、
本番のGitHub APIへ投稿せずに組み立て済みのcreateReviewパラメータをJSON出力できるようにします。

`bin/submit-review.ts`に`Options.boolean("dry-run")`を追加し、
フラグが指定されたときは`createOctokitClient`を呼ばずに`previewReview`を実行します。
出力フォーマットは`{"dryRun": true, "params": {...}}`で、
通常投稿時の`{reviewId, htmlUrl}`と判別できる形にしています。

`src/submit-review.ts`では、
createReviewパラメータの組み立て部分を`buildCreateReviewParams`へ抽出し、
`submitReview`と新規`previewReview`の双方から再利用します。
`previewReview`は入力スキーマの検証(`decodeReviewSubmission`)と、
メタデータフッター生成(`mkBodyAppendMetadata`)を実走するため、
パイプライン全体の動作確認になります。
既存`submitReview`の関数シグネチャや戻り値型は変更していません。

`SKILL.md`にも`--dry-run`の使い方を追記しました。
通常のレビューワークフローでは使わない旨も明示しています。

`--dry-run`は内部動作確認用フラグで既存挙動への影響がないため、
プラグインバージョンはpatchで`3.2.1`から`3.2.2`に上げます。

close #191
