### PR TITLE
feat(kyosei): 前回レビューから実コード変更がない場合は調査をスキップ

### DIFF
--- a/plugins/kyosei/.claude-plugin/plugin.json
+++ b/plugins/kyosei/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kyosei",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Code review for PRs or local changes. Covers code quality, dependency updates, performance, test coverage, documentation accuracy, and security.",
   "author": {
     "name": "ncaq",

--- a/plugins/kyosei/README.md
+++ b/plugins/kyosei/README.md
@@ -7,36 +7,75 @@ Covers code quality, dependency updates, performance, test coverage, documentati
 
 ## モチベーション
 
+### 公式のワークフローが再レビューを行わなくなった
+
 Claude Codeの`install-github-app`でインストールされるClaude Code Reviewのワークフローは、
 同じPRに対してpush後の再レビューを行いません。
 初回のレビュー以降、コードを修正してpushしても新たなレビューが実行されないため、
 指摘事項への対応が正しく行われたかを自動で確認できないという致命的な問題があります。
 
+### claude-code-actionが採用していた方式ベースで動くようにしました
+
 kyoseiは、
 [claude-code-action](https://github.com/anthropics/claude-code-action)
 リポジトリが採用しているレビューパターンをベースにこの問題を解決しています。
 
-ただしclaude-code-actionを直接使う場合にも以下の問題があるので、
+内部でレビューエージェントを複数並列移動するスキルを作って、
+それを起動する形をとっています。
+
+### claude-code-actionからの改良
+
+ただしclaude-code-actionが使っているパターンでは不十分に感じる点があったため、
 kyoseiではさらに改善を加えています。
+
+#### 同じ指摘の防止
+
+claude-code-actionのものをそのまま移植すると、
 
 - 同じPRにpushを繰り返すと、既に指摘済みの同じコメントが何度も投稿される
 - 「意図的です」「仕様です」と返答済みの指摘に対しても、再度同じコメントが投稿される
 
-kyoseiはPRの既存会話(コメント、インラインコメント、レビューコメント)を事前に収集し、
+という問題が発生します。
+
+kyoseiはPRの既存会話(コメント、インラインコメント、レビューコメントなど)を事前に収集し、
 既に指摘済みの内容やresolvedされたコメント、意図的であると返答済みの指摘を除外することで、
 本当に必要な新しいフィードバックだけを提供します。
 
-さらにkyoseiはCIだけでなくローカルでも実行できるため、
+#### コスト削減のため変更のない場合レビューをスキップ
+
+前回のkyoseiレビューと比較して以下のような形で実コードに変更がない場合、
+
+- masterのマージのみ
+- dependabot/renovateのrebase
+- `--no-edit`での署名し直しなど
+
+サブエージェントによる詳細調査をスキップして前回判定を引き継いだ簡易レビューを投稿します。
+これによりLLMの使用量を削減して、
+rate limitに達するリスクを減らします。
+
+レビュー本文末尾に付与されているメタデータフッターから前回対象コミットを復元することで、
+force pushでコミットSHAが変わったケースも追跡します。
+
+#### ローカルでも実行できます
+
+kyoseiはCIだけでなくローカルでも実行できるため、
 pushしてCIの完了を待つことなく手元で即座にレビューを確認でき、
 高速にイテレーションを回すことができます。
 
-またclaude-code-actionのエージェントに含まれている、
+#### プロジェクト特有のノイズの除去
+
+claude-code-actionのエージェントに含まれている、
 プロジェクト固有のコーディング規約によるノイズを除外しています。
+
 例えばclaude-code-actionのcode-quality-reviewerエージェントには
-「Prefer `type` over `interface` as per project standards」
-というTypeScript固有の指示が含まれていますが、
+
+> Prefer `type` over `interface` as per project standards
+
+と言ったTypeScript固有の指示が含まれていますが、
 これはレビュー対象がTypeScriptを含まないプロジェクトであっても適用されてしまいます。
-そういったプロジェクト固有の規約は`CLAUDE.md`などで指定することを想定しています。
+
+そういったプロジェクト固有の規約は`CLAUDE.md`やプラグインで指定することを想定して、
+レビュースキル自体からは削除しています。
 
 ## 前提条件
 

--- a/plugins/kyosei/README.md
+++ b/plugins/kyosei/README.md
@@ -20,7 +20,7 @@ kyoseiは、
 [claude-code-action](https://github.com/anthropics/claude-code-action)
 リポジトリが採用しているレビューパターンをベースにこの問題を解決しています。
 
-内部でレビューエージェントを複数並列移動するスキルを作って、
+内部でレビューエージェントを複数並列起動するスキルを作って、
 それを起動する形をとっています。
 
 ### claude-code-actionからの改良

--- a/plugins/kyosei/package-lock.json
+++ b/plugins/kyosei/package-lock.json
@@ -10,9 +10,11 @@
         "@effect/platform": "^0.96.1",
         "@effect/platform-node": "^0.106.0",
         "effect": "^3.21.1",
+        "fp-ts": "^2.16.11",
         "git-url-parse": "^16.1.0",
         "mustache": "^4.2.0",
         "octokit": "^5.0.5",
+        "parser-ts": "^0.7.0",
         "semver": "^7.7.4"
       },
       "devDependencies": {
@@ -38,6 +40,35 @@
       },
       "engines": {
         "node": ">=20.20.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@effect/cli": {
@@ -3554,6 +3585,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fp-ts": {
+      "version": "2.16.11",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.11.tgz",
+      "integrity": "sha512-LaI+KaX2NFkfn1ZGHoKCmcfv7yrZsC3b8NtWsTVQeHkq4F27vI5igUuO53sxqDEa2gNQMHFPmpojDw/1zmUK7w==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4145,6 +4182,18 @@
         "node": ">=14.13.0"
       }
     },
+    "node_modules/parser-ts": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/parser-ts/-/parser-ts-0.7.0.tgz",
+      "integrity": "sha512-YBJYgQ6j2DiKryKkYUrw0a7WiUb2DGnanffFZNz5cRTaoTncSxjKCio6ocEBSAa26jFXr0XSNjaYXUrL61BISA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0"
+      },
+      "peerDependencies": {
+        "fp-ts": "^2.14.0"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4186,7 +4235,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {

--- a/plugins/kyosei/package.json
+++ b/plugins/kyosei/package.json
@@ -18,9 +18,11 @@
     "@effect/platform": "^0.96.1",
     "@effect/platform-node": "^0.106.0",
     "effect": "^3.21.1",
+    "fp-ts": "^2.16.11",
     "git-url-parse": "^16.1.0",
     "mustache": "^4.2.0",
     "octokit": "^5.0.5",
+    "parser-ts": "^0.7.0",
     "semver": "^7.7.4"
   },
   "devDependencies": {

--- a/plugins/kyosei/skills/kyosei/SKILL.md
+++ b/plugins/kyosei/skills/kyosei/SKILL.md
@@ -50,7 +50,7 @@ GitHub出力モードでは常に含まれます。
 ローカル出力モードでもブランチに紐付くPRがあれば含まれます。
 PRが特定できない場合はフィールド自体が省略されます。
 
-トップレベルにPR自体の情報(`title`, `body`, `author`, `url`)があり、以下の3つのサブフィールドがあります。
+トップレベルにPR自体の情報(`title`, `body`, `author`, `url`など)があり、以下の3つのサブフィールドがあります。
 
 - `comments`: PR全体へのコメント一覧。以下のフィールドを持ちます。
   - `id`
@@ -73,6 +73,75 @@ PRが特定できない場合はフィールド自体が省略されます。
   - `line`
   - `diffSide`
   - `comments`: スレッド内配列
+
+### `previousReview` フィールド(前回kyoseiレビューが復元できた場合のみ)
+
+過去のレビュー本文末尾のメタデータフッターから復元できた最新のkyoseiレビューが含まれます。
+復元できなければフィールド自体が省略されます。
+
+- `reviewId`: GitHubのreview ID
+- `event`: 前回のreview state(`APPROVED`, `CHANGES_REQUESTED`, `COMMENTED`等)
+- `submittedAt`: 投稿時刻(ISO 8601 UTC)
+- `metadata`: フッターから復元したメタデータ全体
+  - `commit`: 特にここに前回レビュー対象コミットSHAが入ります
+
+### `incrementalChangeset` フィールド(`previousReview`があり`headCommitId`が取れる場合のみ)
+
+前回レビュー対象コミットから現headへの増分判定です。
+`status`の値で取り扱いを分岐します。
+
+- `status`: 以下のいずれか
+  - `"tree-identical"`: 前回と現headのGit treeが同一。dependabot/renovateの典型挙動。
+    - rebaseして差分がない
+    - 署名し直し
+    - force pushで同一に戻った
+  - `"diff-empty"`: tree SHAは異なるが、`compareCommits.files`の実際の差分の行(`additions+deletions`合計)が0。masterマージのみなど。
+  - `"diff-present"`: 実コード変更行が存在する。通常レビューに倒します。
+  - `"lookup-failed"`: API取得失敗(SHAがGCで消えた等)。フェイルセーフで通常レビューに倒します。
+- `baseSha`, `headSha`: 比較対象コミット
+- 以下は参考情報。`lookup-failed`時は省略されます。
+  - `baseTreeSha`
+  - `headTreeSha`
+  - `aheadBy`
+  - `behindBy`
+  - `changedFileCount`
+  - `changedLineCount`
+
+# 前回レビューによる動作の分岐
+
+## 簡易レビューの実行
+
+`incrementalChangeset.status`が`"tree-identical"`または`"diff-empty"`の場合は、
+サブエージェントを一切起動せず、
+前回レビューの判定を引き継いだ簡易レビューを組み立てて投稿してください。
+Claudeの使用量を節約するための分岐です。
+
+投稿JSONは以下のように組み立ててください。
+
+- `body`は`status`に応じた一文を中心に組み立てます。
+  - `"tree-identical"`: 例
+    - 前回レビューのcommit (コミット番号) からツリー内容に変更はありません。
+      rebaseによる更新のみ。
+      前回判定を維持します。
+  - `"diff-empty"`: 例
+    - 前回レビューのcommit (コミット番号) 以降は実コード変更がないマージのみです。
+      前回判定を維持します。
+- `comments`は空配列。
+- `event`は`previousReview.event`を引き継ぐ。
+  `previousReview.event`が`APPROVED`なら`"APPROVE"`、
+  `CHANGES_REQUESTED`なら`"REQUEST_CHANGES"`、
+  `COMMENTED`等それ以外は`"COMMENT"`に、
+  マップしてください。
+- `metadata.model`は通常通り渡してください。
+- `headCommitId`は`changeset.headCommitId`を使います。
+
+フィードバックの出力セクションまでスキップしてください。
+
+## 通常レビューの実行
+
+`status`が`"diff-present"`/`"lookup-failed"`、
+もしくは`incrementalChangeset`/`previousReview`フィールド自体が無い場合は、
+通常フローを実行してください。
 
 # コードレビューの実行
 

--- a/plugins/kyosei/src/incremental-changeset.ts
+++ b/plugins/kyosei/src/incremental-changeset.ts
@@ -1,0 +1,157 @@
+/**
+ * 前回レビュー対象コミットから現headまでの「増分changeset」を判定するモジュール。
+ */
+
+import { Effect, Either, Schema } from "effect";
+import type { Octokit } from "octokit";
+import type { PrIdentifier } from "./context-type";
+import { ShaSchema } from "./review-schema";
+
+const NonNegativeIntSchema = Schema.Number.pipe(Schema.int(), Schema.nonNegative());
+
+export const IncrementalChangesetStatusSchema = Schema.Literal(
+  "tree-identical", // tree SHA同一。rebase no-edit / 署名し直し / force pushして同一など。
+  "diff-empty", // tree SHAは異なるが、`compareCommits`の`files`合算で`additions+deletions`が0。masterマージのみ等。
+  "diff-present", // 実コード変更あり。通常レビューに倒します。
+  "lookup-failed", // API取得に失敗。SHAがGCで消えた等。フェイルセーフで通常レビューに倒します。
+);
+
+/**
+ * 増分changesetの出力スキーマ。
+ * `status`単一フィールドでスキップ可否と理由を表します。
+ * `lookup-failed`時はbaseSha/headSha/status以外のフィールドを省いて返します。
+ */
+export const IncrementalChangesetSchema = Schema.Struct({
+  baseSha: ShaSchema,
+  headSha: ShaSchema,
+  baseTreeSha: Schema.optionalWith(ShaSchema, { exact: true }),
+  headTreeSha: Schema.optionalWith(ShaSchema, { exact: true }),
+  aheadBy: Schema.optionalWith(NonNegativeIntSchema, { exact: true }),
+  behindBy: Schema.optionalWith(NonNegativeIntSchema, { exact: true }),
+  changedFileCount: Schema.optionalWith(NonNegativeIntSchema, { exact: true }),
+  changedLineCount: Schema.optionalWith(NonNegativeIntSchema, { exact: true }),
+  status: IncrementalChangesetStatusSchema,
+});
+
+interface CompareFile {
+  readonly additions?: number;
+  readonly deletions?: number;
+}
+
+interface CompareResult {
+  readonly aheadBy: number;
+  readonly behindBy: number;
+  readonly files: readonly CompareFile[];
+}
+
+function getCommitTreeSha(octokit: Octokit, target: PrIdentifier, sha: string): Effect.Effect<string, Error> {
+  return Effect.tryPromise({
+    try: async () => {
+      const response = await octokit.rest.git.getCommit({
+        owner: target.owner,
+        repo: target.repo,
+        commit_sha: sha,
+      });
+      return response.data.tree.sha;
+    },
+    catch: (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+  });
+}
+
+function compareCommits(
+  octokit: Octokit,
+  target: PrIdentifier,
+  baseSha: string,
+  headSha: string,
+): Effect.Effect<CompareResult, Error> {
+  return Effect.tryPromise({
+    try: async () => {
+      const response = await octokit.rest.repos.compareCommits({
+        owner: target.owner,
+        repo: target.repo,
+        base: baseSha,
+        head: headSha,
+      });
+      return {
+        aheadBy: response.data.ahead_by,
+        behindBy: response.data.behind_by,
+        files:
+          response.data.files?.map<CompareFile>((file) => ({
+            additions: file.additions,
+            deletions: file.deletions,
+          })) ?? [],
+      };
+    },
+    catch: (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+  });
+}
+
+function sumLineChanges(files: readonly CompareFile[]): number {
+  return files.reduce((acc, file) => acc + (file.additions ?? 0) + (file.deletions ?? 0), 0);
+}
+
+function buildLookupFailed(baseSha: string, headSha: string): typeof IncrementalChangesetSchema.Type {
+  return Schema.decodeUnknownSync(IncrementalChangesetSchema)({
+    baseSha,
+    headSha,
+    status: "lookup-failed",
+  });
+}
+
+/**
+ * 前回レビュー対象コミット(`baseSha`)から現head(`headSha`)までの増分を判定します。
+ * APIエラーは`Effect.fail`にせず`status: "lookup-failed"`にフォールバックさせます。
+ */
+export function getIncrementalChangeset(
+  octokit: Octokit,
+  target: PrIdentifier,
+  baseSha: string,
+  headSha: string,
+): Effect.Effect<typeof IncrementalChangesetSchema.Type, never> {
+  return Effect.gen(function* () {
+    const fetched = yield* Effect.all(
+      [
+        getCommitTreeSha(octokit, target, baseSha),
+        getCommitTreeSha(octokit, target, headSha),
+        compareCommits(octokit, target, baseSha, headSha),
+      ],
+      { concurrency: "unbounded" },
+    ).pipe(Effect.either);
+
+    if (Either.isLeft(fetched)) {
+      yield* Effect.logWarning(`failed to compute incremental changeset: ${fetched.left.message}`);
+      return buildLookupFailed(baseSha, headSha);
+    }
+
+    const [baseTreeSha, headTreeSha, compare] = fetched.right;
+    const changedFileCount = compare.files.length;
+    const changedLineCount = sumLineChanges(compare.files);
+
+    if (baseTreeSha === headTreeSha) {
+      return Schema.decodeUnknownSync(IncrementalChangesetSchema)({
+        baseSha,
+        headSha,
+        baseTreeSha,
+        headTreeSha,
+        aheadBy: compare.aheadBy,
+        behindBy: compare.behindBy,
+        changedFileCount,
+        changedLineCount,
+        status: "tree-identical",
+      });
+    }
+
+    const status: "diff-empty" | "diff-present" = changedLineCount === 0 ? "diff-empty" : "diff-present";
+    return Schema.decodeUnknownSync(IncrementalChangesetSchema)({
+      baseSha,
+      headSha,
+      baseTreeSha,
+      headTreeSha,
+      aheadBy: compare.aheadBy,
+      behindBy: compare.behindBy,
+      changedFileCount,
+      changedLineCount,
+      status,
+    });
+  });
+}

--- a/plugins/kyosei/src/previous-review.ts
+++ b/plugins/kyosei/src/previous-review.ts
@@ -1,0 +1,68 @@
+/**
+ * PRの`Conversation`から、過去のkyoseiレビューのうちフッターメタデータを復元できる最新のものを抽出するモジュール。
+ * レビューはフェイルセーフとして少しでも違う場合は積極的に復元失敗とします。
+ */
+
+import { DateTime, Either, Option, Order, Schema } from "effect";
+import type { Conversation } from "./conversation";
+import { MetadataSchema } from "./review-metadata";
+import { parseFooterMetadata } from "./review-metadata-parser";
+
+/**
+ * 過去のkyoseiレビューを表すスキーマ。
+ */
+export const PreviousReviewSchema = Schema.Struct({
+  reviewId: Schema.NonEmptyString,
+  event: Schema.NonEmptyString,
+  /** `submittedAt`はUTCの日時として保存して、ISO 8601文字列に戻します。 */
+  submittedAt: Schema.DateTimeUtc,
+  metadata: MetadataSchema,
+});
+
+type ReviewCandidate = typeof PreviousReviewSchema.Type;
+
+const decodeDateTimeUtc = Schema.decodeUnknownEither(Schema.DateTimeUtc);
+
+/** 1件のreviewから候補を組み立てます。失敗時は`Option.none`を返します。 */
+function toCandidate(review: Conversation["reviews"][number]): Option.Option<ReviewCandidate> {
+  const metadata = parseFooterMetadata(review.body);
+  const submittedAt = decodeDateTimeUtc(review.submittedAt);
+  if (review.submittedAt == null || Option.isNone(metadata) || Either.isLeft(submittedAt)) {
+    return Option.none();
+  }
+  return Option.some({
+    reviewId: review.id,
+    event: review.state,
+    submittedAt: submittedAt.right,
+    metadata: metadata.value,
+  });
+}
+
+const candidateOrderDesc = Order.reverse(
+  Order.mapInput(DateTime.Order, (candidate: ReviewCandidate) => candidate.submittedAt),
+);
+
+/**
+ * conversationから、フッターメタデータを復元できる最新のkyoseiレビューを返します。
+ * 候補がなければ`Option.none`。
+ */
+export function pickPreviousKyoseiReview(conversation: Conversation): Option.Option<typeof PreviousReviewSchema.Type> {
+  const candidates = conversation.reviews
+    .map((review) => toCandidate(review))
+    .filter(Option.isSome)
+    .map((review) => review.value)
+    .toSorted(candidateOrderDesc);
+  if (candidates.length === 0) {
+    return Option.none();
+  }
+  const latest = candidates[0];
+  if (latest == null) {
+    return Option.none();
+  }
+  return Option.some({
+    reviewId: latest.reviewId,
+    event: latest.event,
+    submittedAt: latest.submittedAt,
+    metadata: latest.metadata,
+  });
+}

--- a/plugins/kyosei/src/previous-review.ts
+++ b/plugins/kyosei/src/previous-review.ts
@@ -3,7 +3,7 @@
  * レビューはフェイルセーフとして少しでも違う場合は積極的に復元失敗とします。
  */
 
-import { DateTime, Either, Option, Order, Schema } from "effect";
+import { DateTime, Either, Option, Schema } from "effect";
 import type { Conversation } from "./conversation";
 import { MetadataSchema } from "./review-metadata";
 import { parseFooterMetadata } from "./review-metadata-parser";
@@ -38,26 +38,19 @@ function toCandidate(review: Conversation["reviews"][number]): Option.Option<Rev
   });
 }
 
-const candidateOrderDesc = Order.reverse(
-  Order.mapInput(DateTime.Order, (candidate: ReviewCandidate) => candidate.submittedAt),
-);
-
 /**
  * conversationから、フッターメタデータを復元できる最新のkyoseiレビューを返します。
  * 候補がなければ`Option.none`。
  */
 export function pickPreviousKyoseiReview(conversation: Conversation): Option.Option<typeof PreviousReviewSchema.Type> {
-  const candidates = conversation.reviews
-    .map((review) => toCandidate(review))
-    .filter(Option.isSome)
-    .map((review) => review.value)
-    .toSorted(candidateOrderDesc);
-  if (candidates.length === 0) {
-    return Option.none();
-  }
-  const latest = candidates[0];
-  if (latest == null) {
-    return Option.none();
-  }
-  return Option.some(latest);
+  return conversation.reviews.reduce<Option.Option<ReviewCandidate>>((acc, review) => {
+    const candidate = toCandidate(review);
+    if (Option.isNone(candidate)) {
+      return acc;
+    }
+    if (Option.isNone(acc) || DateTime.Order(candidate.value.submittedAt, acc.value.submittedAt) > 0) {
+      return candidate;
+    }
+    return acc;
+  }, Option.none());
 }

--- a/plugins/kyosei/src/previous-review.ts
+++ b/plugins/kyosei/src/previous-review.ts
@@ -27,7 +27,7 @@ const decodeDateTimeUtc = Schema.decodeUnknownEither(Schema.DateTimeUtc);
 function toCandidate(review: Conversation["reviews"][number]): Option.Option<ReviewCandidate> {
   const metadata = parseFooterMetadata(review.body);
   const submittedAt = decodeDateTimeUtc(review.submittedAt);
-  if (review.submittedAt == null || Option.isNone(metadata) || Either.isLeft(submittedAt)) {
+  if (Option.isNone(metadata) || Either.isLeft(submittedAt)) {
     return Option.none();
   }
   return Option.some({

--- a/plugins/kyosei/src/previous-review.ts
+++ b/plugins/kyosei/src/previous-review.ts
@@ -59,10 +59,5 @@ export function pickPreviousKyoseiReview(conversation: Conversation): Option.Opt
   if (latest == null) {
     return Option.none();
   }
-  return Option.some({
-    reviewId: latest.reviewId,
-    event: latest.event,
-    submittedAt: latest.submittedAt,
-    metadata: latest.metadata,
-  });
+  return Option.some(latest);
 }

--- a/plugins/kyosei/src/review-info.ts
+++ b/plugins/kyosei/src/review-info.ts
@@ -1,41 +1,68 @@
 /**
  * レビュー情報を統合して取得するモジュール。
  * 変更セット取得と会話取得を1回の呼び出しで行います。
+ * PRが特定できかつ前回kyoseiレビューがある場合は、増分changesetも併せて返します。
  */
 
 import { type CommandExecutor } from "@effect/platform";
-import { Effect } from "effect";
+import { Effect, Option } from "effect";
 import type { Octokit } from "octokit";
 import type { Changeset } from "./changeset";
 import { getChangeset } from "./changeset";
 import type { ReviewContext } from "./context-type";
 import type { Conversation } from "./conversation";
 import { getConversation } from "./conversation";
+import { getIncrementalChangeset, type IncrementalChangesetSchema } from "./incremental-changeset";
+import { pickPreviousKyoseiReview, type PreviousReviewSchema } from "./previous-review";
 
 /** レビュー情報。conversationはPRが特定できた場合のみ含まれます。 */
 export interface ReviewInfo {
   readonly context: ReviewContext;
   readonly changeset: Changeset;
   readonly conversation?: Conversation;
+  readonly previousReview?: typeof PreviousReviewSchema.Type;
+  readonly incrementalChangeset?: typeof IncrementalChangesetSchema.Type;
 }
 
 /**
  * レビューコンテキストに応じてレビュー情報を統合的に取得します。
  * PRが特定できている場合はchangesetとconversationを並列で取得します。
+ * 前回kyoseiレビューが復元できかつ`headCommitId`が取れている場合のみ、増分changesetを追加で取得します。
  */
 export function getReviewInfo(
   octokit: Octokit,
   context: ReviewContext,
 ): Effect.Effect<ReviewInfo, Error, CommandExecutor.CommandExecutor> {
   return Effect.gen(function* () {
-    if (context.pr != null) {
-      const [changeset, conversation] = yield* Effect.all(
-        [getChangeset(octokit, context), getConversation(octokit, context.pr)],
-        { concurrency: "unbounded" },
-      );
+    if (context.pr == null) {
+      const changeset = yield* getChangeset(octokit, context);
+      return { context, changeset };
+    }
+
+    const [changeset, conversation] = yield* Effect.all(
+      [getChangeset(octokit, context), getConversation(octokit, context.pr)],
+      { concurrency: "unbounded" },
+    );
+
+    const previousReviewOption = pickPreviousKyoseiReview(conversation);
+    if (Option.isNone(previousReviewOption) || changeset.headCommitId == null) {
       return { context, changeset, conversation };
     }
-    const changeset = yield* getChangeset(octokit, context);
-    return { context, changeset };
+
+    const previousReview = previousReviewOption.value;
+    const incrementalChangeset = yield* getIncrementalChangeset(
+      octokit,
+      context.pr,
+      previousReview.metadata.commit,
+      changeset.headCommitId,
+    );
+
+    return {
+      context,
+      changeset,
+      conversation,
+      previousReview,
+      incrementalChangeset,
+    };
   });
 }

--- a/plugins/kyosei/src/review-metadata-parser.ts
+++ b/plugins/kyosei/src/review-metadata-parser.ts
@@ -1,0 +1,120 @@
+/**
+ * レビュー本文の末尾に付与されているメタデータフッターをパースして`MetadataSchema`相当の値に復元するモジュール。
+ * `review-metadata-footer.mustache`がレンダリングしたブロックを、parser-tsのパーサーコンビネータで読み戻します。
+ *
+ * 復元できなくても通常レビューにフォールバックするため、厳密な失敗種別の区別はしません。
+ * 失敗時は一律で`Option.none()`を返します。
+ */
+
+import { Option, Schema } from "effect";
+import { isRight } from "fp-ts/Either";
+import { pipe } from "fp-ts/function";
+import * as P from "parser-ts/Parser";
+import { stream } from "parser-ts/Stream";
+import * as C from "parser-ts/char";
+import * as S from "parser-ts/string";
+import { MetadataSchema } from "./review-metadata";
+
+const newline = C.char("\n");
+
+/** 改行直前までの文字列(改行は含まない)。 */
+const restOfLine: P.Parser<C.Char, string> = C.many(C.notChar("\n"));
+
+/** `<details>`ブロックを成立させるために、その手前にある任意のbody本文を読み飛ばす。 */
+const skipUntilDetails: P.Parser<C.Char, string> = pipe(
+  P.manyTill(P.item<C.Char>(), pipe(S.string("<details>"), P.lookAhead)),
+  P.map((chars) => chars.join("")),
+);
+
+/** `- {label}: {value}\n`の1行をパースして value を返す。 */
+function labeledLine(label: string): P.Parser<C.Char, string> {
+  return pipe(S.string(`- ${label}: `), P.apSecond(restOfLine), P.apFirst(newline));
+}
+
+/** `- PR: #{number}\n`の値部分から数値を取り出す。 */
+const prLine: P.Parser<C.Char, number> = pipe(
+  S.string("- PR: #"),
+  P.apSecond(S.int),
+  P.apFirst(restOfLine),
+  P.apFirst(newline),
+);
+
+interface ExecutionInfo {
+  readonly execution: string;
+  readonly runUrl?: string;
+}
+
+/** `- Execution: {execution} ([run]({url}))\n`形式 */
+const executionWithRun: P.Parser<C.Char, ExecutionInfo> = pipe(
+  S.string("- Execution: "),
+  P.apSecond(
+    pipe(
+      P.manyTill(P.item<C.Char>(), pipe(S.string(" ([run]("), P.lookAhead)),
+      P.bindTo("executionChars"),
+      P.apFirst(S.string(" ([run](")),
+      P.bind("urlChars", () => P.manyTill(P.item<C.Char>(), S.string("))"))),
+      P.apFirst(newline),
+      P.map(({ executionChars, urlChars }) => ({
+        execution: executionChars.join(""),
+        runUrl: urlChars.join(""),
+      })),
+    ),
+  ),
+);
+
+/** `- Execution: {execution}\n`形式(runUrlなし) */
+const executionPlain: P.Parser<C.Char, ExecutionInfo> = pipe(
+  labeledLine("Execution"),
+  P.map((execution) => ({ execution })),
+);
+
+const executionLineParser: P.Parser<C.Char, ExecutionInfo> = pipe(
+  executionWithRun,
+  P.alt(() => executionPlain),
+);
+
+/**
+ * `<details>...</details>`ブロックを丸ごと飲み込んで、各フィールドを構造体として返す。
+ * フィールドの並び順は`review-metadata-footer.mustache`に固定されているため、
+ * パーサーも同じ順で固定的に走査する。
+ */
+const metadataBlockParser = pipe(
+  skipUntilDetails,
+  P.apSecond(S.string("<details>")),
+  P.apSecond(newline),
+  P.apSecond(S.string("<summary>Review metadata</summary>")),
+  P.apSecond(newline),
+  P.apSecond(newline),
+  P.apSecond(labeledLine("Reviewed commit")),
+  P.bindTo("commit"),
+  P.bind("pr", () => prLine),
+  P.bind("kyoseiVersion", () => labeledLine("kyosei")),
+  P.bind("kyoseiActionVersion", () => labeledLine("kyosei-action")),
+  P.bind("claudeCodeVersion", () => labeledLine("Claude Code")),
+  P.bind("model", () => labeledLine("Model")),
+  P.bind("executionInfo", () => executionLineParser),
+);
+
+/**
+ * フッターメタデータをパースします。
+ * 復元失敗時は`Option.none`を返し、呼び出し側は通常レビューにフォールバックさせます。
+ */
+export function parseFooterMetadata(body: string): Option.Option<typeof MetadataSchema.Type> {
+  const result = metadataBlockParser(stream(body.split(""), 0));
+  if (!isRight(result)) {
+    return Option.none();
+  }
+  const { commit, pr, kyoseiVersion, kyoseiActionVersion, claudeCodeVersion, model, executionInfo } =
+    result.right.value;
+  const decoded = Schema.decodeUnknownEither(MetadataSchema)({
+    commit,
+    pr,
+    kyoseiVersion,
+    kyoseiActionVersion,
+    claudeCodeVersion,
+    model,
+    execution: executionInfo.execution,
+    ...(executionInfo.runUrl != null ? { runUrl: executionInfo.runUrl } : {}),
+  });
+  return decoded._tag === "Right" ? Option.some(decoded.right) : Option.none();
+}

--- a/plugins/kyosei/src/review-metadata.ts
+++ b/plugins/kyosei/src/review-metadata.ts
@@ -19,7 +19,33 @@ import mustache from "mustache";
 import pluginManifest from "../.claude-plugin/plugin.json" with { type: "json" };
 import internalErrorsSectionTemplate from "./internal-errors-section.mustache?raw";
 import reviewMetadataFooterTemplate from "./review-metadata-footer.mustache?raw";
-import { ExecutionSchema, FooterViewSchema, pickNonBlank, ReviewSubmissionSchema } from "./review-schema";
+import {
+  ExecutionSchema,
+  NonEmptyStringOrUnknownSchema,
+  pickNonBlank,
+  PrNumberSchema,
+  ReviewSubmissionSchema,
+  SemVerOrUnknownSchema,
+  SemVerSchema,
+  ShaSchema,
+} from "./review-schema";
+
+/**
+ * レビューフッターのメタデータスキーマ。
+ * レンダリング(投稿時)とパース復元(再レビュー時)の両方で同じ型を往復させます。
+ * `commit`/`pr`/`kyoseiVersion`は`unknown`フォールバックを設けません。
+ * これらが欠落しているフッターは復元失敗扱い(=通常レビューにフォールバック)とします。
+ */
+export const MetadataSchema = Schema.Struct({
+  commit: ShaSchema,
+  pr: PrNumberSchema,
+  kyoseiVersion: SemVerSchema,
+  kyoseiActionVersion: SemVerOrUnknownSchema,
+  claudeCodeVersion: SemVerOrUnknownSchema,
+  model: NonEmptyStringOrUnknownSchema,
+  execution: ExecutionSchema,
+  runUrl: Schema.optionalWith(Schema.URL, { exact: true }),
+});
 
 /**
  * `claude --version` の出力からバージョン文字列を抽出します。
@@ -69,16 +95,16 @@ function lookupRunUrlString(): Option.Option<string> {
 
 /**
  * フッターレンダリング用のビューを構築します。
- * 各フィールドの正規化(SHA形式の判定、空文字の扱い、SemVer判定など)は`FooterViewSchema`が担うため、
+ * 各フィールドの正規化(SHA形式の判定、空文字の扱い、SemVer判定など)は`MetadataSchema`が担うため、
  * ここではrawな値をそのまま渡します。
  */
 export function buildFooterView(
   submission: typeof ReviewSubmissionSchema.Type,
-): Effect.Effect<typeof FooterViewSchema.Type, never, CommandExecutor.CommandExecutor> {
+): Effect.Effect<typeof MetadataSchema.Type, never, CommandExecutor.CommandExecutor> {
   return Effect.gen(function* () {
     const claudeCodeVersion = yield* detectClaudeCodeVersion();
     const runUrl = lookupRunUrlString();
-    return Schema.decodeUnknownSync(FooterViewSchema)({
+    return Schema.decodeUnknownSync(MetadataSchema)({
       commit: submission.headCommitId,
       pr: submission.prNumber,
       kyoseiVersion: pluginManifest.version,

--- a/plugins/kyosei/src/review-metadata.ts
+++ b/plugins/kyosei/src/review-metadata.ts
@@ -50,7 +50,7 @@ export const MetadataSchema = Schema.Struct({
 /**
  * `claude --version` の出力からバージョン文字列を抽出します。
  * 取得に失敗した場合や出力が想定と異なる場合は警告ログを出して`Option.none`を返します。
- * 戻り値は`FooterViewSchema`に渡され、SemVer形式でなければ`"unknown"`に正規化されます。
+ * 戻り値は`MetadataSchema`に渡され、SemVer形式でなければ`"unknown"`に正規化されます。
  */
 function detectClaudeCodeVersion(): Effect.Effect<Option.Option<string>, never, CommandExecutor.CommandExecutor> {
   return Command.string(Command.make("claude", "--version")).pipe(

--- a/plugins/kyosei/src/review-schema.ts
+++ b/plugins/kyosei/src/review-schema.ts
@@ -165,19 +165,3 @@ export const ReviewSubmissionResultSchema = Schema.Struct({
   reviewId: Schema.Number.pipe(Schema.int(), Schema.positive()),
   htmlUrl: Schema.URL,
 });
-
-/**
- * フッターレンダリング直前のビュー。
- * `commit`は`unknown`フォールバックを設けません。
- * レビュー対象を後から辿る上で必須の情報なので、欠落は入力スキーマ側で弾きます。
- */
-export const FooterViewSchema = Schema.Struct({
-  commit: ShaSchema,
-  pr: PrNumberSchema,
-  kyoseiVersion: SemVerSchema,
-  kyoseiActionVersion: SemVerOrUnknownSchema,
-  claudeCodeVersion: SemVerOrUnknownSchema,
-  model: NonEmptyStringOrUnknownSchema,
-  execution: ExecutionSchema,
-  runUrl: Schema.optionalWith(Schema.URL, { exact: true }),
-});

--- a/plugins/kyosei/test/incremental-changeset.test.ts
+++ b/plugins/kyosei/test/incremental-changeset.test.ts
@@ -1,0 +1,168 @@
+import { it } from "@effect/vitest";
+import { Effect } from "effect";
+import type { Octokit } from "octokit";
+import { describe, expect, vi } from "vitest";
+import type { PrIdentifier } from "../src/context-type";
+import { getIncrementalChangeset } from "../src/incremental-changeset";
+
+const target: PrIdentifier = { owner: "test-owner", repo: "test-repo", prNumber: 42 };
+const baseSha = "abcdef1abcdef1abcdef1abcdef1abcdef1abcd";
+const headSha = "1234567123456712345671234567123456712345";
+
+interface FakeFile {
+  readonly additions: number;
+  readonly deletions: number;
+}
+
+function buildOctokit(overrides: {
+  baseTreeSha?: string;
+  headTreeSha?: string;
+  aheadBy?: number;
+  behindBy?: number;
+  files?: readonly FakeFile[];
+  failGetCommit?: boolean;
+  failCompare?: boolean;
+}): Octokit {
+  const treeBySha: Record<string, string | undefined> = {
+    [baseSha]: overrides.baseTreeSha,
+    [headSha]: overrides.headTreeSha,
+  };
+  const getCommit = vi.fn(({ commit_sha }: { commit_sha: string }) => {
+    if (overrides.failGetCommit === true) {
+      return Promise.reject(new Error("getCommit failed"));
+    }
+    const sha = treeBySha[commit_sha];
+    if (sha == null) {
+      return Promise.reject(new Error(`unknown sha: ${commit_sha}`));
+    }
+    return Promise.resolve({ data: { tree: { sha } } });
+  });
+  const compareCommits = vi.fn(() => {
+    if (overrides.failCompare === true) {
+      return Promise.reject(new Error("compareCommits failed"));
+    }
+    return Promise.resolve({
+      data: {
+        ahead_by: overrides.aheadBy ?? 0,
+        behind_by: overrides.behindBy ?? 0,
+        files: overrides.files ?? [],
+      },
+    });
+  });
+  return {
+    rest: {
+      git: { getCommit },
+      repos: { compareCommits },
+    },
+  } as unknown as Octokit;
+}
+
+describe("getIncrementalChangeset", () => {
+  it.effect("tree SHA一致なら tree-identical", () =>
+    Effect.gen(function* () {
+      const octokit = buildOctokit({
+        baseTreeSha: "aaa0000000000000000000000000000000000000",
+        headTreeSha: "aaa0000000000000000000000000000000000000",
+        aheadBy: 1,
+        behindBy: 1,
+        files: [{ additions: 5, deletions: 3 }],
+      });
+
+      const result = yield* getIncrementalChangeset(octokit, target, baseSha, headSha);
+
+      expect(result.status).toBe("tree-identical");
+      expect(result.baseTreeSha).toBe("aaa0000000000000000000000000000000000000");
+      expect(result.headTreeSha).toBe("aaa0000000000000000000000000000000000000");
+    }),
+  );
+
+  it.effect("tree異なる + filesが空なら diff-empty", () =>
+    Effect.gen(function* () {
+      const octokit = buildOctokit({
+        baseTreeSha: "bbb1000000000000000000000000000000000000",
+        headTreeSha: "ccc2000000000000000000000000000000000000",
+        aheadBy: 1,
+        behindBy: 0,
+        files: [],
+      });
+
+      const result = yield* getIncrementalChangeset(octokit, target, baseSha, headSha);
+
+      expect(result.status).toBe("diff-empty");
+      expect(result.changedFileCount).toBe(0);
+      expect(result.changedLineCount).toBe(0);
+    }),
+  );
+
+  it.effect("tree異なる + 全fileがadditions=0 deletions=0 なら diff-empty(リネームのみ等)", () =>
+    Effect.gen(function* () {
+      const octokit = buildOctokit({
+        baseTreeSha: "bbb1000000000000000000000000000000000000",
+        headTreeSha: "ccc2000000000000000000000000000000000000",
+        aheadBy: 1,
+        behindBy: 0,
+        files: [
+          { additions: 0, deletions: 0 },
+          { additions: 0, deletions: 0 },
+        ],
+      });
+
+      const result = yield* getIncrementalChangeset(octokit, target, baseSha, headSha);
+
+      expect(result.status).toBe("diff-empty");
+      expect(result.changedFileCount).toBe(2);
+      expect(result.changedLineCount).toBe(0);
+    }),
+  );
+
+  it.effect("tree異なる + 一部fileに実差分行があれば diff-present(コンフリクト解決を含むmerge等)", () =>
+    Effect.gen(function* () {
+      const octokit = buildOctokit({
+        baseTreeSha: "bbb1000000000000000000000000000000000000",
+        headTreeSha: "ccc2000000000000000000000000000000000000",
+        aheadBy: 1,
+        behindBy: 0,
+        files: [
+          { additions: 0, deletions: 0 },
+          { additions: 3, deletions: 1 },
+        ],
+      });
+
+      const result = yield* getIncrementalChangeset(octokit, target, baseSha, headSha);
+
+      expect(result.status).toBe("diff-present");
+      expect(result.changedFileCount).toBe(2);
+      expect(result.changedLineCount).toBe(4);
+    }),
+  );
+
+  it.effect("getCommitが失敗したら lookup-failed", () =>
+    Effect.gen(function* () {
+      const octokit = buildOctokit({
+        baseTreeSha: "bbb1000000000000000000000000000000000000",
+        headTreeSha: "ccc2000000000000000000000000000000000000",
+        failGetCommit: true,
+      });
+
+      const result = yield* getIncrementalChangeset(octokit, target, baseSha, headSha);
+
+      expect(result.status).toBe("lookup-failed");
+      expect(result.baseTreeSha).toBeUndefined();
+      expect(result.headTreeSha).toBeUndefined();
+    }),
+  );
+
+  it.effect("compareCommitsが失敗したら lookup-failed", () =>
+    Effect.gen(function* () {
+      const octokit = buildOctokit({
+        baseTreeSha: "bbb1000000000000000000000000000000000000",
+        headTreeSha: "ccc2000000000000000000000000000000000000",
+        failCompare: true,
+      });
+
+      const result = yield* getIncrementalChangeset(octokit, target, baseSha, headSha);
+
+      expect(result.status).toBe("lookup-failed");
+    }),
+  );
+});

--- a/plugins/kyosei/test/previous-review.test.ts
+++ b/plugins/kyosei/test/previous-review.test.ts
@@ -1,0 +1,160 @@
+import { DateTime, Option } from "effect";
+import { describe, expect, test } from "vitest";
+import type { Conversation, ConversationReview } from "../src/conversation";
+import { pickPreviousKyoseiReview } from "../src/previous-review";
+
+function buildFooter(commit: string, version = "3.3.0"): string {
+  return [
+    "<details>",
+    "<summary>Review metadata</summary>",
+    "",
+    `- Reviewed commit: ${commit}`,
+    "- PR: #178",
+    `- kyosei: ${version}`,
+    "- kyosei-action: unknown",
+    "- Claude Code: unknown",
+    "- Model: claude-opus-4-7",
+    "- Execution: Claude Code CLI",
+    "",
+    "</details>",
+  ].join("\n");
+}
+
+function makeReview(overrides: Partial<ConversationReview>): ConversationReview {
+  return {
+    id: "R1",
+    author: "kyosei-bot",
+    state: "COMMENTED",
+    body: "summary text",
+    submittedAt: "2026-04-01T00:00:00Z",
+    url: "https://github.com/test/repo/pull/1#pullrequestreview-1",
+    ...overrides,
+  };
+}
+
+function makeConversation(reviews: ConversationReview[]): Conversation {
+  return {
+    title: "PR title",
+    body: "PR body",
+    author: "author",
+    url: "https://github.com/test/repo/pull/1",
+    comments: [],
+    reviews,
+    reviewThreads: [],
+  };
+}
+
+describe("pickPreviousKyoseiReview", () => {
+  test("メタデータ付きレビューが1件あれば抽出できる", () => {
+    const conversation = makeConversation([
+      makeReview({
+        id: "R1",
+        state: "APPROVED",
+        body: `LGTM\n\n${buildFooter("a214aef83b6ce8f")}`,
+        submittedAt: "2026-04-01T00:00:00Z",
+      }),
+    ]);
+
+    const result = pickPreviousKyoseiReview(conversation);
+
+    expect(Option.isSome(result)).toBe(true);
+    if (Option.isSome(result)) {
+      expect(result.value.reviewId).toBe("R1");
+      expect(result.value.metadata.commit).toBe("a214aef83b6ce8f");
+      expect(result.value.event).toBe("APPROVED");
+      expect(result.value.metadata.pr).toBe(178);
+      expect(DateTime.toDateUtc(result.value.submittedAt).toISOString()).toBe("2026-04-01T00:00:00.000Z");
+    }
+  });
+
+  test("submittedAtが新しい順で最新が選ばれる(逆順入力でも)", () => {
+    const conversation = makeConversation([
+      makeReview({
+        id: "older",
+        body: `prev\n\n${buildFooter("aaaaaaa")}`,
+        submittedAt: "2026-04-01T00:00:00Z",
+      }),
+      makeReview({
+        id: "newer",
+        body: `latest\n\n${buildFooter("bbbbbbb")}`,
+        submittedAt: "2026-04-15T00:00:00Z",
+      }),
+      makeReview({
+        id: "middle",
+        body: `middle\n\n${buildFooter("ccccccc")}`,
+        submittedAt: "2026-04-10T00:00:00Z",
+      }),
+    ]);
+
+    const result = pickPreviousKyoseiReview(conversation);
+
+    expect(Option.isSome(result)).toBe(true);
+    if (Option.isSome(result)) {
+      expect(result.value.reviewId).toBe("newer");
+      expect(result.value.metadata.commit).toBe("bbbbbbb");
+    }
+  });
+
+  test("メタデータ無しレビューはスキップ", () => {
+    const conversation = makeConversation([
+      makeReview({ id: "no-metadata", body: "LGTM", submittedAt: "2026-04-15T00:00:00Z" }),
+      makeReview({
+        id: "with-metadata",
+        body: `summary\n\n${buildFooter("a214aef83b6ce8f")}`,
+        submittedAt: "2026-04-01T00:00:00Z",
+      }),
+    ]);
+
+    const result = pickPreviousKyoseiReview(conversation);
+
+    expect(Option.isSome(result)).toBe(true);
+    if (Option.isSome(result)) {
+      expect(result.value.reviewId).toBe("with-metadata");
+    }
+  });
+
+  test("submittedAtがnullのレビューはスキップ", () => {
+    const conversation = makeConversation([
+      makeReview({ id: "no-submitted-at", body: `summary\n\n${buildFooter("aaaaaaa")}`, submittedAt: null }),
+      makeReview({
+        id: "valid",
+        body: `summary\n\n${buildFooter("bbbbbbb")}`,
+        submittedAt: "2026-04-10T00:00:00Z",
+      }),
+    ]);
+
+    const result = pickPreviousKyoseiReview(conversation);
+
+    expect(Option.isSome(result)).toBe(true);
+    if (Option.isSome(result)) {
+      expect(result.value.reviewId).toBe("valid");
+    }
+  });
+
+  test("候補が無ければNone", () => {
+    const conversation = makeConversation([makeReview({ body: "no metadata at all" })]);
+    expect(pickPreviousKyoseiReview(conversation)).toEqual(Option.none());
+  });
+
+  test("kyoseiバージョンがSemVer形式でないレビューは除外される", () => {
+    const conversation = makeConversation([
+      makeReview({
+        id: "broken",
+        body: `summary\n\n${buildFooter("aaaaaaa", "not-semver")}`,
+        submittedAt: "2026-04-15T00:00:00Z",
+      }),
+      makeReview({
+        id: "valid",
+        body: `summary\n\n${buildFooter("bbbbbbb")}`,
+        submittedAt: "2026-04-10T00:00:00Z",
+      }),
+    ]);
+
+    const result = pickPreviousKyoseiReview(conversation);
+
+    expect(Option.isSome(result)).toBe(true);
+    if (Option.isSome(result)) {
+      expect(result.value.reviewId).toBe("valid");
+    }
+  });
+});

--- a/plugins/kyosei/test/review-info.test.ts
+++ b/plugins/kyosei/test/review-info.test.ts
@@ -1,9 +1,11 @@
 import { it } from "@effect/vitest";
-import { Effect } from "effect";
+import { Effect, Option, Schema } from "effect";
 import type { Octokit } from "octokit";
 import { beforeEach, describe, expect, vi } from "vitest";
 import { getChangeset } from "../src/changeset";
 import { getConversation } from "../src/conversation";
+import { getIncrementalChangeset, IncrementalChangesetSchema } from "../src/incremental-changeset";
+import { pickPreviousKyoseiReview, PreviousReviewSchema } from "../src/previous-review";
 import { getReviewInfo } from "../src/review-info";
 import { fakeCommandExecutor } from "./fake-command";
 
@@ -15,11 +17,34 @@ vi.mock("../src/conversation", () => ({
   getConversation: vi.fn(),
 }));
 
+vi.mock("../src/previous-review", async () => {
+  const actual = await vi.importActual<typeof import("../src/previous-review")>("../src/previous-review");
+  return {
+    ...actual,
+    pickPreviousKyoseiReview: vi.fn(),
+  };
+});
+
+vi.mock("../src/incremental-changeset", async () => {
+  const actual = await vi.importActual<typeof import("../src/incremental-changeset")>("../src/incremental-changeset");
+  return {
+    ...actual,
+    getIncrementalChangeset: vi.fn(),
+  };
+});
+
 const mockedGetChangeset = vi.mocked(getChangeset);
 const mockedGetConversation = vi.mocked(getConversation);
+const mockedPickPrevious = vi.mocked(pickPreviousKyoseiReview);
+const mockedGetIncremental = vi.mocked(getIncrementalChangeset);
 
 const dummyOctokit = {} as Octokit;
 const dummyChangeset = { diff: "diff", log: "log" };
+const dummyChangesetWithHead = {
+  diff: "diff",
+  log: "log",
+  headCommitId: "feedfacefeedfacefeedfacefeedfacefeedface",
+};
 const dummyConversation = {
   title: "PR",
   body: "",
@@ -30,11 +55,36 @@ const dummyConversation = {
   reviewThreads: [],
 };
 
+const dummyPreviousReview = Schema.decodeUnknownSync(PreviousReviewSchema)({
+  reviewId: "R1",
+  commit: "abcdef1abcdef1abcdef1abcdef1abcdef1abcd1",
+  event: "APPROVED",
+  submittedAt: "2026-04-01T00:00:00Z",
+  metadata: {
+    commit: "abcdef1abcdef1abcdef1abcdef1abcdef1abcd1",
+    pr: 1,
+    kyoseiVersion: "3.3.0",
+    kyoseiActionVersion: "unknown",
+    claudeCodeVersion: "unknown",
+    model: "claude-opus-4-7",
+    execution: "Claude Code CLI" as const,
+  },
+});
+const dummyIncrementalChangeset = Schema.decodeUnknownSync(IncrementalChangesetSchema)({
+  baseSha: "abcdef1abcdef1abcdef1abcdef1abcdef1abcd1",
+  headSha: "feedfacefeedfacefeedfacefeedfacefeedface",
+  baseTreeSha: "aaa0000000000000000000000000000000000000",
+  headTreeSha: "aaa0000000000000000000000000000000000000",
+  status: "tree-identical",
+});
+
 const noCommandLayer = fakeCommandExecutor(() => Effect.die(new Error("CommandExecutor should not be invoked")));
 
 describe("getReviewInfo", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockedPickPrevious.mockReturnValue(Option.none());
+    mockedGetIncremental.mockReturnValue(Effect.succeed(dummyIncrementalChangeset));
   });
 
   it.layer(noCommandLayer)((it) => {
@@ -74,7 +124,10 @@ describe("getReviewInfo", () => {
         expect(reviewInfo.context).toBe(context);
         expect(reviewInfo.changeset).toBe(dummyChangeset);
         expect(reviewInfo.conversation).toBeUndefined();
+        expect(reviewInfo.previousReview).toBeUndefined();
+        expect(reviewInfo.incrementalChangeset).toBeUndefined();
         expect(mockedGetConversation).not.toHaveBeenCalled();
+        expect(mockedGetIncremental).not.toHaveBeenCalled();
       }),
     );
 
@@ -92,6 +145,71 @@ describe("getReviewInfo", () => {
         const reviewInfo = yield* getReviewInfo(dummyOctokit, context);
 
         expect(reviewInfo.conversation).toBe(dummyConversation);
+      }),
+    );
+
+    it.effect("previousReviewが取れてheadCommitIdもあればincrementalChangesetも返す", () =>
+      Effect.gen(function* () {
+        mockedGetChangeset.mockReturnValue(Effect.succeed(dummyChangesetWithHead));
+        mockedGetConversation.mockReturnValue(Effect.succeed(dummyConversation));
+        mockedPickPrevious.mockReturnValue(Option.some(dummyPreviousReview));
+
+        const context = {
+          output: "github" as const,
+          host: "github.com",
+          pr: { owner: "test", repo: "repo", prNumber: 1 },
+        };
+
+        const reviewInfo = yield* getReviewInfo(dummyOctokit, context);
+
+        expect(reviewInfo.previousReview).toBe(dummyPreviousReview);
+        expect(reviewInfo.incrementalChangeset).toBe(dummyIncrementalChangeset);
+        expect(mockedGetIncremental).toHaveBeenCalledWith(
+          dummyOctokit,
+          context.pr,
+          dummyPreviousReview.metadata.commit,
+          dummyChangesetWithHead.headCommitId,
+        );
+      }),
+    );
+
+    it.effect("previousReviewが取れてもheadCommitIdが無ければincrementalChangesetは省く", () =>
+      Effect.gen(function* () {
+        mockedGetChangeset.mockReturnValue(Effect.succeed(dummyChangeset)); // headCommitIdなし
+        mockedGetConversation.mockReturnValue(Effect.succeed(dummyConversation));
+        mockedPickPrevious.mockReturnValue(Option.some(dummyPreviousReview));
+
+        const context = {
+          output: "local" as const,
+          pr: { owner: "test", repo: "repo", prNumber: 1 },
+          baseBranch: "master",
+        };
+
+        const reviewInfo = yield* getReviewInfo(dummyOctokit, context);
+
+        expect(reviewInfo.previousReview).toBeUndefined();
+        expect(reviewInfo.incrementalChangeset).toBeUndefined();
+        expect(mockedGetIncremental).not.toHaveBeenCalled();
+      }),
+    );
+
+    it.effect("previousReviewが取れなければincrementalChangesetも省く", () =>
+      Effect.gen(function* () {
+        mockedGetChangeset.mockReturnValue(Effect.succeed(dummyChangesetWithHead));
+        mockedGetConversation.mockReturnValue(Effect.succeed(dummyConversation));
+        mockedPickPrevious.mockReturnValue(Option.none());
+
+        const context = {
+          output: "github" as const,
+          host: "github.com",
+          pr: { owner: "test", repo: "repo", prNumber: 1 },
+        };
+
+        const reviewInfo = yield* getReviewInfo(dummyOctokit, context);
+
+        expect(reviewInfo.previousReview).toBeUndefined();
+        expect(reviewInfo.incrementalChangeset).toBeUndefined();
+        expect(mockedGetIncremental).not.toHaveBeenCalled();
       }),
     );
   });

--- a/plugins/kyosei/test/review-info.test.ts
+++ b/plugins/kyosei/test/review-info.test.ts
@@ -57,7 +57,6 @@ const dummyConversation = {
 
 const dummyPreviousReview = Schema.decodeUnknownSync(PreviousReviewSchema)({
   reviewId: "R1",
-  commit: "abcdef1abcdef1abcdef1abcdef1abcdef1abcd1",
   event: "APPROVED",
   submittedAt: "2026-04-01T00:00:00Z",
   metadata: {

--- a/plugins/kyosei/test/review-metadata-parser.test.ts
+++ b/plugins/kyosei/test/review-metadata-parser.test.ts
@@ -1,0 +1,138 @@
+import { it } from "@effect/vitest";
+import { Effect, Option } from "effect";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { buildReviewBody } from "../src/review-metadata";
+import { parseFooterMetadata } from "../src/review-metadata-parser";
+import { decodeReviewSubmission } from "../src/submit-review";
+import { fakeCommandExecutor } from "./fake-command";
+
+const claudeFakeLayer = fakeCommandExecutor(() => Effect.fail(new Error("claude not installed in test environment")));
+
+const baseInput = {
+  owner: "test-owner",
+  repo: "test-repo",
+  prNumber: 178,
+  event: "COMMENT",
+  body: "review summary",
+  headCommitId: "a214aef83b6ce8f",
+};
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+  vi.stubEnv("KYOSEI_ACTION_VERSION", "");
+  vi.stubEnv("GITHUB_ACTIONS", "");
+  vi.stubEnv("GITHUB_SERVER_URL", "");
+  vi.stubEnv("GITHUB_REPOSITORY", "");
+  vi.stubEnv("GITHUB_RUN_ID", "");
+  vi.stubEnv("CLAUDECODE", "");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("parseFooterMetadata", () => {
+  it.layer(claudeFakeLayer)((it) => {
+    it.effect("ローカル実行で生成したフッターを往復で復元できる", () =>
+      Effect.gen(function* () {
+        vi.stubEnv("CLAUDECODE", "1");
+        const submission = decodeReviewSubmission(
+          JSON.stringify({ ...baseInput, metadata: { model: "claude-opus-4-7" } }),
+        );
+
+        const body = yield* buildReviewBody(submission);
+        const restored = parseFooterMetadata(body);
+
+        expect(Option.isSome(restored)).toBe(true);
+        if (Option.isSome(restored)) {
+          expect(restored.value.commit).toBe("a214aef83b6ce8f");
+          expect(restored.value.pr).toBe(178);
+          expect(restored.value.model).toBe("claude-opus-4-7");
+          expect(restored.value.execution).toBe("Claude Code CLI");
+          expect(restored.value.runUrl).toBeUndefined();
+        }
+      }),
+    );
+
+    it.effect("GitHub Actions環境のrunUrl付きフッターを往復で復元できる", () =>
+      Effect.gen(function* () {
+        vi.stubEnv("GITHUB_ACTIONS", "true");
+        vi.stubEnv("GITHUB_SERVER_URL", "https://github.com");
+        vi.stubEnv("GITHUB_REPOSITORY", "ncaq/konoka");
+        vi.stubEnv("GITHUB_RUN_ID", "123");
+        const submission = decodeReviewSubmission(JSON.stringify(baseInput));
+
+        const body = yield* buildReviewBody(submission);
+        const restored = parseFooterMetadata(body);
+
+        expect(Option.isSome(restored)).toBe(true);
+        if (Option.isSome(restored)) {
+          expect(restored.value.execution).toBe("GitHub Actions");
+          expect(restored.value.runUrl).toEqual(new URL("https://github.com/ncaq/konoka/actions/runs/123"));
+        }
+      }),
+    );
+  });
+
+  test("メタデータブロックが存在しない場合はNone", () => {
+    expect(parseFooterMetadata("just a body without metadata")).toEqual(Option.none());
+  });
+
+  test("`<summary>`が異なるdetailsブロックは無視してNone", () => {
+    const body = "<details>\n<summary>Other</summary>\n\n- Reviewed commit: abcdef1\n\n</details>";
+    expect(parseFooterMetadata(body)).toEqual(Option.none());
+  });
+
+  test("Reviewed commitが欠落していればNone", () => {
+    const body = [
+      "<details>",
+      "<summary>Review metadata</summary>",
+      "",
+      "- PR: #178",
+      "- kyosei: 3.3.0",
+      "- kyosei-action: unknown",
+      "- Claude Code: unknown",
+      "- Model: claude-opus-4-7",
+      "- Execution: Claude Code CLI",
+      "",
+      "</details>",
+    ].join("\n");
+    expect(parseFooterMetadata(body)).toEqual(Option.none());
+  });
+
+  test("commitがSHA形式でなければNone", () => {
+    const body = [
+      "<details>",
+      "<summary>Review metadata</summary>",
+      "",
+      "- Reviewed commit: not-a-sha",
+      "- PR: #178",
+      "- kyosei: 3.3.0",
+      "- kyosei-action: unknown",
+      "- Claude Code: unknown",
+      "- Model: claude-opus-4-7",
+      "- Execution: Claude Code CLI",
+      "",
+      "</details>",
+    ].join("\n");
+    expect(parseFooterMetadata(body)).toEqual(Option.none());
+  });
+
+  test("kyoseiバージョンがSemVer形式でなければNone(将来のフォーマット変更時のフェイルセーフ)", () => {
+    const body = [
+      "<details>",
+      "<summary>Review metadata</summary>",
+      "",
+      "- Reviewed commit: a214aef83b6ce8f",
+      "- PR: #178",
+      "- kyosei: not-semver",
+      "- kyosei-action: unknown",
+      "- Claude Code: unknown",
+      "- Model: claude-opus-4-7",
+      "- Execution: Claude Code CLI",
+      "",
+      "</details>",
+    ].join("\n");
+    expect(parseFooterMetadata(body)).toEqual(Option.none());
+  });
+});


### PR DESCRIPTION
同じPRに対するpush後の再レビューでも、masterのマージのみ、dependabot/renovateのrebase、 `git commit --amend --no-edit`での署名し直しといった実コード変更が無いケースで、 6個のサブエージェントによる並列レビューが毎回走り、Claudeのトークンを消費していました。
rate limitに到達しやすく、コストにも直結するため、
こうしたケースは前回判定を引き継いだ簡易レビューに切り替えてサブエージェント起動を回避します。

仕組みは以下の構成です。

- 投稿側のフッターメタデータ(`<details>...</details>`)に既に必要な情報を載せていたため、 これを次回起動時に読み戻して前回レビュー対象コミットSHAを復元します。 そのために投稿時のレンダリングと再レビュー時のパースで同じ型を往復できるよう、 `FooterViewSchema`を`MetadataSchema`に改名のうえ`review-metadata.ts`へ移しました。
- `previous-review.ts`でPR会話の`reviews`配列から最新のkyoseiレビューを抽出します。 `submittedAt`は`Schema.DateTimeUtc`で日時型として扱い、`DateTime.Order`の逆順で並べ替えています。
- `incremental-changeset.ts`で前回commit(`baseSha`)から現head(`headSha`)への増分を分類します。 `getCommit.tree.sha`の比較と`compareCommits.files`の`additions+deletions`合計から、 `tree-identical`(rebase/amend/force pushで戻った等)、 `diff-empty`(masterマージのみ等)、 `diff-present`(コンフリクト解決を含む実変更)、 `lookup-failed`(SHAがGCで消えた等)の4状態を単一の`status`フィールドにまとめます。 verdictとreasonに分けると論理的な整合性が崩れるため一本化しました。 API取得失敗時は`Effect.fail`にせず`lookup-failed`にフォールバックさせ、 通常レビューに倒す設計にしています。
- `getReviewInfo`はPRが特定でき、前回kyoseiレビューが復元でき、 かつ`headCommitId`が取得できた場合のみ`incrementalChangeset`を併せて返します。
- `SKILL.md`の冒頭で`status`に応じた分岐を定義し、 `tree-identical`/`diff-empty`ではサブエージェントを起動せず、 前回`event`を引き継いだ簡易レビューを組み立てて投稿するようLLMに指示します。 `lookup-failed`/`diff-present`、または`incrementalChangeset`/`previousReview`が無い場合は通常フローを実行します。

フッターパーサーは当初正規表現と`Map`で実装しましたが、
固定順の`- Label: Value`行が7行あり、Execution行のRun URLサフィックスで分岐が必要なため、 規模が増えると将来のフィールド追加や順序変更で破綻しやすい構造でした。
そこで`parser-ts`のパーサーコンビネータに置き換え、
ラベル順を`P.bind`チェインで`review-metadata-footer.mustache`と同じ並びに対応付け、 Run URLは`executionWithRun`/`executionPlain`の`alt`で型レベルに分離しています。 `parser-ts`は`fp-ts`に依存しますがEffect本体とは独立に使え、
パーサ部分のみ`fp-ts/Either`からEffectの`Option`に変換して呼び出し側のAPIは維持しています。

スキップ判定の追加でレビュー出力の挙動が変わるため、
プラグインバージョンを`3.3.0`から`3.4.0`にminor bumpします。

close #117