### PR TITLE
build(rm-to-trash): 依存クレートのバージョンをパッチバージョンまで明示

### DIFF
--- a/plugins/rm-to-trash/Cargo.toml
+++ b/plugins/rm-to-trash/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2024"
 publish = false
 
 [dependencies]
-regex-lite = "0.1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+regex-lite = "0.1.9"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
Cargo.lockに記録されている実際のバージョンに合わせて、
`regex-lite`、`serde`、`serde_json`のバージョン指定をパッチバージョンまで明示しました。
renovateで管理しているためメンテナンスコストは変わらず、
バージョンの意図が分かりやすくなります。
