### PR TITLE
refactor(commit,pr): editorスクリプトをbashからTypeScriptに書き直す

### DIFF
--- a/plugins/commit/bin/editor
+++ b/plugins/commit/bin/editor
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-${EDITOR:-emacsclient --reuse-frame --alternate-editor=emacs} "$@"

--- a/plugins/commit/bin/editor.ts
+++ b/plugins/commit/bin/editor.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+
+const editorEnv = process.env["EDITOR"];
+const [editor = "emacsclient", ...defaultArgs] = editorEnv
+  ? editorEnv.split(" ")
+  : ["emacsclient", "--reuse-frame", "--alternate-editor=emacs"];
+
+const result = spawnSync(editor, [...defaultArgs, ...process.argv.slice(2)], {
+  stdio: "inherit",
+});
+
+process.exit(result.status ?? 1);

--- a/plugins/commit/bin/editor.ts
+++ b/plugins/commit/bin/editor.ts
@@ -11,4 +11,14 @@ const result = spawnSync(editor, [...defaultArgs, ...process.argv.slice(2)], {
   stdio: "inherit",
 });
 
-process.exit(result.status ?? 1);
+function assertEditorSuccess(editorName: string, { error, status }: { error?: Error; status: number | null }): void {
+  if (error !== undefined || status !== 0) {
+    const detail = error !== undefined ? `: ${error.message}` : "";
+    throw new Error(
+      `Editor "${editorName}" failed (status ${status})${detail}`,
+      error !== undefined ? { cause: error } : undefined,
+    );
+  }
+}
+
+assertEditorSuccess(editor, result);

--- a/plugins/commit/package-lock.json
+++ b/plugins/commit/package-lock.json
@@ -7,6 +7,7 @@
       "name": "konoka-commit",
       "bin": {
         "commit-prepare.ts": "bin/commit-prepare.ts",
+        "editor.ts": "bin/editor.ts",
         "read-commit-instructions.ts": "bin/read-commit-instructions.ts"
       },
       "devDependencies": {

--- a/plugins/commit/package.json
+++ b/plugins/commit/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "bin": {
     "commit-prepare.ts": "./bin/commit-prepare.ts",
+    "editor.ts": "./bin/editor.ts",
     "read-commit-instructions.ts": "./bin/read-commit-instructions.ts"
   },
   "scripts": {

--- a/plugins/commit/skills/commit/SKILL.md
+++ b/plugins/commit/skills/commit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: commit
 description: Generate a commit message from staged changes and let the user review before committing. Use when the user wants to commit changes or create a git commit.
-allowed-tools: AskUserQuestion, Bash(commit-prepare.ts:*), Bash(editor:*), Bash(git commit:*), Edit, Read, Skill(commit-style)
+allowed-tools: AskUserQuestion, Bash(commit-prepare.ts:*), Bash(editor.ts:*), Bash(git commit:*), Edit, Read, Skill(commit-style)
 ---
 
 Gitリポジトリの変更をコミットします。
@@ -67,7 +67,7 @@ AIがコミットメッセージを生成し、
 タイムアウトは最大の600秒(10分)に設定してください。
 
 ```bash
-editor <editmsgのパス>
+editor.ts <editmsgのパス>
 ```
 
 エディタが正常終了したら、

--- a/plugins/pr/bin/editor
+++ b/plugins/pr/bin/editor
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-${EDITOR:-emacsclient --reuse-frame --alternate-editor=emacs} "$@"

--- a/plugins/pr/bin/editor.ts
+++ b/plugins/pr/bin/editor.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+
+const editorEnv = process.env["EDITOR"];
+const [editor = "emacsclient", ...defaultArgs] = editorEnv
+  ? editorEnv.split(" ")
+  : ["emacsclient", "--reuse-frame", "--alternate-editor=emacs"];
+
+const result = spawnSync(editor, [...defaultArgs, ...process.argv.slice(2)], {
+  stdio: "inherit",
+});
+
+process.exit(result.status ?? 1);

--- a/plugins/pr/bin/editor.ts
+++ b/plugins/pr/bin/editor.ts
@@ -11,4 +11,14 @@ const result = spawnSync(editor, [...defaultArgs, ...process.argv.slice(2)], {
   stdio: "inherit",
 });
 
-process.exit(result.status ?? 1);
+function assertEditorSuccess(editorName: string, { error, status }: { error?: Error; status: number | null }): void {
+  if (error !== undefined || status !== 0) {
+    const detail = error !== undefined ? `: ${error.message}` : "";
+    throw new Error(
+      `Editor "${editorName}" failed (status ${status})${detail}`,
+      error !== undefined ? { cause: error } : undefined,
+    );
+  }
+}
+
+assertEditorSuccess(editor, result);

--- a/plugins/pr/package-lock.json
+++ b/plugins/pr/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "konoka-pr",
       "bin": {
+        "editor.ts": "bin/editor.ts",
         "prepare-editmsg.ts": "bin/prepare-editmsg.ts",
         "read-contributing.ts": "bin/read-contributing.ts",
         "read-pull-request-template.ts": "bin/read-pull-request-template.ts",

--- a/plugins/pr/package.json
+++ b/plugins/pr/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "bin": {
+    "editor.ts": "./bin/editor.ts",
     "prepare-editmsg.ts": "./bin/prepare-editmsg.ts",
     "read-contributing.ts": "./bin/read-contributing.ts",
     "read-pull-request-template.ts": "./bin/read-pull-request-template.ts",

--- a/plugins/pr/skills/pr/SKILL.md
+++ b/plugins/pr/skills/pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pr
 description: Generate a GitHub pull request title and body from the current branch and let the user review before creation. Use when the user wants to create a pull request.
-allowed-tools: AskUserQuestion, Bash(editor:*), Bash(git status:*), Bash(prepare-editmsg.ts:*), Bash(sync-and-push.ts:*), Edit, Read, Skill(pr-style), Write, mcp__github__create_pull_request, mcp__github__issue_write
+allowed-tools: AskUserQuestion, Bash(editor.ts:*), Bash(git status:*), Bash(prepare-editmsg.ts:*), Bash(sync-and-push.ts:*), Edit, Read, Skill(pr-style), Write, mcp__github__create_pull_request, mcp__github__issue_write
 ---
 
 GitHubのpull requestを作成します。
@@ -133,7 +133,7 @@ PR作成に進んでください。
 タイムアウトは最大の600秒に設定してください。
 
 ```bash
-editor <PR_EDITMSGのパス>
+editor.ts <PR_EDITMSGのパス>
 ```
 
 エディタが正常終了したら、


### PR DESCRIPTION
commitとprプラグインのbinスクリプトはTypeScriptで統一されているのに、
`editor`だけbashスクリプトのままだったため、一貫性のためTypeScriptに移植しました。

`EDITOR`環境変数をスペース分割してコマンドと引数に分離し、
`spawnSync`で`stdio: "inherit"`として対話的に実行します。
終了コードは子プロセスのものをそのまま`process.exit`で引き渡します。

また、他のbinスクリプトと同様に`.ts`拡張子を付与し、
SKILL.mdの`allowed-tools`とコマンド例の参照も`editor.ts`に更新しました。