### PR TITLE
fix(hooks): ビルドフックの競合防止とrm-to-trashの実行条件を追加

### DIFF
--- a/plugins/kyosei/.claude-plugin/plugin.json
+++ b/plugins/kyosei/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kyosei",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Code review for PRs or local changes. Covers code quality, dependency updates, performance, test coverage, documentation accuracy, and security.",
   "author": {
     "name": "ncaq",

--- a/plugins/kyosei/hooks/build
+++ b/plugins/kyosei/hooks/build
@@ -1,17 +1,27 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# `dist/`が存在すればビルド済みなので何もしません。
-# プラグイン更新時は`CLAUDE_PLUGIN_ROOT`ごと入れ替わり`dist/`も消えるため、
-# この存在チェックだけで初回・更新後の両方を検知できます。
+# ビルド済みなら何もせず即座に終了します。
+# プラグイン更新時は`CLAUDE_PLUGIN_ROOT`ごと入れ替わりビルドしたファイルも消えるため、
+# 初回・更新後の両方でビルドされていないことを検知できます。
 [ -d "${CLAUDE_PLUGIN_ROOT}/dist" ] && exit 0
 
-# ビルドされていなかったのでビルドとインストールを行います。
-echo "Installing dependencies and building kyosei plugin..."
+# 競合防止のためにロックを取得します。
+exec 9>"${CLAUDE_PLUGIN_ROOT}/.build.lock"
+flock 9
 
-# プロジェクトのディレクトリに移動。
+# ロックしている間に他のプロセスがビルドしていたら終了します。
+[ -d "${CLAUDE_PLUGIN_ROOT}/dist" ] && exit 0
+
+# 必要なコマンドが存在するか簡易検証します。
+if ! command -v npm &>/dev/null; then
+  echo "Error: npm is not found. Install Node.js to build the plugin." >&2
+  exit 1
+fi
+
+# ディレクトリを固定します。
 cd "${CLAUDE_PLUGIN_ROOT}"
-# 依存関係をインストール。
+# 依存関係をインストールします。
 npm ci
-# プログラムをビルド。
+# ビルドします。
 npm run build

--- a/plugins/kyosei/hooks/build
+++ b/plugins/kyosei/hooks/build
@@ -8,7 +8,7 @@ set -euo pipefail
 
 # 競合防止のためにロックを取得します。
 exec 9>"${CLAUDE_PLUGIN_ROOT}/.build.lock"
-flock 9
+flock --wait 250 9
 
 # ロックしている間に他のプロセスがビルドしていたら終了します。
 [ -d "${CLAUDE_PLUGIN_ROOT}/dist" ] && exit 0

--- a/plugins/kyosei/hooks/hooks.json
+++ b/plugins/kyosei/hooks/hooks.json
@@ -6,7 +6,19 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/build",
-            "timeout": 500
+            "timeout": 300
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Skill|SlashCommand",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/build",
+            "timeout": 300
           }
         ]
       }

--- a/plugins/rm-to-trash/.claude-plugin/plugin.json
+++ b/plugins/rm-to-trash/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rm-to-trash",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Auto-rewrites bare `rm <file>` to `trash <file>` in Bash commands via PreToolUse hook.",
   "author": {
     "name": "ncaq",

--- a/plugins/rm-to-trash/hooks/build
+++ b/plugins/rm-to-trash/hooks/build
@@ -4,14 +4,14 @@ set -euo pipefail
 # ビルド済みなら何もせず即座に終了します。
 # プラグイン更新時は`CLAUDE_PLUGIN_ROOT`ごと入れ替わりビルドしたファイルも消えるため、
 # 初回・更新後の両方でビルドされていないことを検知できます。
-[ -d "${CLAUDE_PLUGIN_ROOT}/target/release" ] && exit 0
+[ -x "${CLAUDE_PLUGIN_ROOT}/target/release/rm-to-trash" ] && exit 0
 
 # 競合防止のためにロックを取得します。
 exec 9>"${CLAUDE_PLUGIN_ROOT}/.build.lock"
 flock 9
 
 # ロックしている間に他のプロセスがビルドしていたら終了します。
-[ -d "${CLAUDE_PLUGIN_ROOT}/target/release" ] && exit 0
+[ -x "${CLAUDE_PLUGIN_ROOT}/target/release/rm-to-trash" ] && exit 0
 
 # 必要なコマンドが存在するか簡易検証します。
 if ! command -v cargo &>/dev/null; then

--- a/plugins/rm-to-trash/hooks/build
+++ b/plugins/rm-to-trash/hooks/build
@@ -8,7 +8,7 @@ set -euo pipefail
 
 # 競合防止のためにロックを取得します。
 exec 9>"${CLAUDE_PLUGIN_ROOT}/.build.lock"
-flock 9
+flock --wait 250 9
 
 # ロックしている間に他のプロセスがビルドしていたら終了します。
 [ -x "${CLAUDE_PLUGIN_ROOT}/target/release/rm-to-trash" ] && exit 0

--- a/plugins/rm-to-trash/hooks/build
+++ b/plugins/rm-to-trash/hooks/build
@@ -1,19 +1,25 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# `rm-to-trash`バイナリがビルド済みであれば何もしません。
-# プラグイン更新時は`CLAUDE_PLUGIN_ROOT`ごと入れ替わって`target/`も消えるため、
-# この存在チェックだけで初回・更新後の両方を検知できます。
-if [[ -x "${CLAUDE_PLUGIN_ROOT}/target/release/rm-to-trash" ]]; then
-  exit 0
-fi
+# ビルド済みなら何もせず即座に終了します。
+# プラグイン更新時は`CLAUDE_PLUGIN_ROOT`ごと入れ替わりビルドしたファイルも消えるため、
+# 初回・更新後の両方でビルドされていないことを検知できます。
+[ -d "${CLAUDE_PLUGIN_ROOT}/target/release" ] && exit 0
 
-# 必要なコマンドが存在するか検証します。
+# 競合防止のためにロックを取得します。
+exec 9>"${CLAUDE_PLUGIN_ROOT}/.build.lock"
+flock 9
+
+# ロックしている間に他のプロセスがビルドしていたら終了します。
+[ -d "${CLAUDE_PLUGIN_ROOT}/target/release" ] && exit 0
+
+# 必要なコマンドが存在するか簡易検証します。
 if ! command -v cargo &>/dev/null; then
   echo "Error: cargo is not found. Install the Rust toolchain to use rm-to-trash." >&2
   exit 1
 fi
 
-echo "Building rm-to-trash..."
+# ディレクトリを固定します。
 cd "${CLAUDE_PLUGIN_ROOT}"
+# ビルドします。
 cargo build --release

--- a/plugins/rm-to-trash/hooks/hooks.json
+++ b/plugins/rm-to-trash/hooks/hooks.json
@@ -17,6 +17,7 @@
         "hooks": [
           {
             "type": "command",
+            "if": "Bash(rm:*)",
             "command": "${CLAUDE_PLUGIN_ROOT}/target/release/rm-to-trash",
             "timeout": 10
           }


### PR DESCRIPTION
`kyosei`と`rm-to-trash`のビルドフックを安定化し、
`rm-to-trash`が不必要に起動するのを防ぎます。

ビルドフックは`Stop`に加えて`PreToolUse`(`Skill|SlashCommand`)でも発火するようにし、
プラグイン更新直後にビルド前のバイナリへアクセスして失敗するケースを減らします。
複数イベントで同時にビルドが走った時にnpmやcargoが衝突しないように、
`flock`でロックを取り、
ロック取得後にビルド済みかを再判定してから処理を実行します。
依存コマンド(`npm`, `cargo`)が見つからない時のエラーメッセージも明確化します。

`rm-to-trash`はこれまで全ての`Bash`実行に対してフックが起動していましたが、
`if`条件で`Bash(rm:*)`の時だけ起動するように制限します。
`rm`を含まないコマンドのたびにバイナリが起動するオーバーヘッドが無くなります。

合わせて`kyosei`と`rm-to-trash`のパッチバージョンを更新します。
