### PR TITLE
refactor(kyosei): vite設定の不要な`require`bannerを削除し`noExternal`の理由を明文化

### DIFF
--- a/plugins/kyosei/vite.config.ts
+++ b/plugins/kyosei/vite.config.ts
@@ -24,11 +24,6 @@ export default defineConfig({
         format: "esm",
         entryFileNames: "[name].js",
         chunkFileNames: "[name].js",
-        // ESM出力下でもCJS依存(octokit配下など)が`require`を期待する場合のフォールバック。
-        banner: [
-          "import { createRequire as ___createRequire } from 'node:module';",
-          "const require = ___createRequire(import.meta.url);",
-        ].join("\n"),
       },
     },
   },

--- a/plugins/kyosei/vite.config.ts
+++ b/plugins/kyosei/vite.config.ts
@@ -29,6 +29,8 @@ export default defineConfig({
   },
   ssr: {
     // 全依存をバンドルに含めます(デフォルトは external のため明示)。
+    // `fp-ts`のようにディレクトリインポート(`from "fp-ts/Either"`)を使うCJSパッケージは、
+    // 外部化したままだとNode.jsのESM resolverが解決できず`ERR_UNSUPPORTED_DIR_IMPORT`になります。
     noExternal: true,
   },
 });


### PR DESCRIPTION
`plugins/kyosei/vite.config.ts`を整理しました。

ESM出力下でCJS依存が`require`を呼ぶケースに備えて`createRequire`によるbannerを挿入していましたが、
実際のバンドル出力に`require(...)`の呼び出しは存在せず不要だったため削除しました。

加えて`ssr.noExternal: true`を解除する案を検証したところ、
`fp-ts/Either`等のディレクトリインポートがNode.jsのESM resolverで`ERR_UNSUPPORTED_DIR_IMPORT`となり、
実行時クラッシュすることが分かりました。
将来同じ案を再検討した時に同じ調査をやり直さなくて済むよう、
`noExternal`を維持している具体的な理由をコメントに残しています。
