### PR TITLE
chore: pluginsディレクトリの.editorconfigを削除

### DIFF
--- a/plugins/.editorconfig
+++ b/plugins/.editorconfig
@@ -1,3 +1,0 @@
-# Agent Skills仕様のフロントマターは1行に書く必要があるため行幅制限を無効化。
-[**/SKILL.md]
-max_line_length = off

--- a/plugins/web-tasuke/skills/as-const-satisfies/SKILL.md
+++ b/plugins/web-tasuke/skills/as-const-satisfies/SKILL.md
@@ -112,7 +112,11 @@ type ShallowReadonlyConfig = Readonly<MutableConfig>;
 // 深い`readonly`化が必要な場合は自前で定義
 // この定義はプレーンオブジェクトと配列のみを対象としています。
 // Map/Set/Date等のビルトインオブジェクトを含む型には専用の対応が必要です。
-type DeepReadonly<T> = T extends readonly (infer U)[] ? readonly DeepReadonly<U>[] : T extends object ? { readonly [P in keyof T]: DeepReadonly<T[P]> } : T;
+type DeepReadonly<T> = T extends readonly (infer U)[]
+  ? readonly DeepReadonly<U>[]
+  : T extends object
+    ? { readonly [P in keyof T]: DeepReadonly<T[P]> }
+    : T;
 
 type ReadonlyConfig = DeepReadonly<MutableConfig>;
 

--- a/plugins/web-tasuke/skills/async-state-type/SKILL.md
+++ b/plugins/web-tasuke/skills/async-state-type/SKILL.md
@@ -63,7 +63,10 @@ Suspenseが使えない場合は、状態を排他的に表現する判別共用
 
 ```typescript
 // Good: 状態が排他的に表現されている
-type AsyncState<T> = { status: "loading" } | { status: "error"; error: Error } | { status: "success"; data: T };
+type AsyncState<T> =
+  | { status: "loading" }
+  | { status: "error"; error: Error }
+  | { status: "success"; data: T };
 ```
 
 `status`フィールドで分岐することで、各状態で利用可能なフィールドが型レベルで保証されます。


### PR DESCRIPTION
フロントマターにより行幅制限を無効にしないといけない都合は、
`.editorconfig-checker.json`で除外することで既に対応されています。
offやunsetにするとEmacsで行幅がデフォルトになってしまい、
100文字に緩和した設定がなくなってしまうため、
無駄な設定は削除します。
