### PR TITLE
refactor(commit): 補助プログラムをEffectベースに書き換えテストを整備

### DIFF
--- a/plugins/commit/.claude-plugin/plugin.json
+++ b/plugins/commit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "commit",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Generate a commit message from staged changes and let the user review before committing. Use when the user wants to commit changes or create a git commit.",
   "author": {
     "name": "ncaq",

--- a/plugins/commit/package-lock.json
+++ b/plugins/commit/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@effect/language-service": "0.86.1",
-        "@effect/vitest": "^0.29.0",
+        "@effect/vitest": "0.29.0",
         "@eslint/compat": "2.1.0",
         "@eslint/js": "10.0.1",
         "@types/node": "22.19.19",

--- a/plugins/commit/package-lock.json
+++ b/plugins/commit/package-lock.json
@@ -5,7 +5,15 @@
   "packages": {
     "": {
       "name": "konoka-commit",
+      "dependencies": {
+        "@effect/cli": "0.75.1",
+        "@effect/platform": "0.96.1",
+        "@effect/platform-node": "0.106.0",
+        "effect": "3.21.2"
+      },
       "devDependencies": {
+        "@effect/language-service": "0.86.1",
+        "@effect/vitest": "^0.29.0",
         "@eslint/compat": "2.1.0",
         "@eslint/js": "10.0.1",
         "@types/node": "22.19.19",
@@ -20,10 +28,217 @@
         "typescript": "6.0.3",
         "typescript-eslint": "8.59.2",
         "vite": "7.3.3",
-        "vitest": "4.1.5"
+        "vitest": "3.2.4"
       },
       "engines": {
         "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@effect/cli": {
+      "version": "0.75.1",
+      "resolved": "https://registry.npmjs.org/@effect/cli/-/cli-0.75.1.tgz",
+      "integrity": "sha512-aDZ1OZzaFAb6NyBOrP+Bl52eICds5ERI9aa67LzloJELt5SCWeNwthtaEacBvvMkwVUcykJ+YHcGCkD1t47g8g==",
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^4.1.3",
+        "toml": "^3.0.0",
+        "yaml": "^2.5.0"
+      },
+      "peerDependencies": {
+        "@effect/platform": "^0.96.0",
+        "@effect/printer": "^0.49.0",
+        "@effect/printer-ansi": "^0.49.0",
+        "effect": "^3.21.1"
+      }
+    },
+    "node_modules/@effect/cluster": {
+      "version": "0.58.2",
+      "resolved": "https://registry.npmjs.org/@effect/cluster/-/cluster-0.58.2.tgz",
+      "integrity": "sha512-oxQ3zUhXq0mJA7Y4TliALMP39Bx0LtAIxcqOW1Bdjh6uk+nG7kul/Puw80SwlcYGv3ul50SG+gvSRUTXB8d3JQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "kubernetes-types": "^1.30.0"
+      },
+      "peerDependencies": {
+        "@effect/platform": "^0.96.1",
+        "@effect/rpc": "^0.75.1",
+        "@effect/sql": "^0.51.1",
+        "@effect/workflow": "^0.18.0",
+        "effect": "^3.21.2"
+      }
+    },
+    "node_modules/@effect/experimental": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@effect/experimental/-/experimental-0.60.0.tgz",
+      "integrity": "sha512-i5zIg7Xup2KgHyqHlYtkgqSE1bNzCL0GbbTQxrpIzKF0q/ebknOk/ox8B/gIq2vImjoEE81h/oxU+6i1NH210g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "uuid": "^11.0.3"
+      },
+      "peerDependencies": {
+        "@effect/platform": "^0.96.0",
+        "effect": "^3.21.0",
+        "ioredis": "^5",
+        "lmdb": "^3"
+      },
+      "peerDependenciesMeta": {
+        "ioredis": {
+          "optional": true
+        },
+        "lmdb": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@effect/language-service": {
+      "version": "0.86.1",
+      "resolved": "https://registry.npmjs.org/@effect/language-service/-/language-service-0.86.1.tgz",
+      "integrity": "sha512-jfUuFdtNPKRZ4ZSrgTnfMHPIVq8L9cM+YGEylQ1lhIgNY23ZvfdPg0cUlWESd4q9aGvOWSA8E79AS0qe3j4ROw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "effect-language-service": "cli.js"
+      }
+    },
+    "node_modules/@effect/platform": {
+      "version": "0.96.1",
+      "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.96.1.tgz",
+      "integrity": "sha512-cjB1QZZYEP8JXCFNGvBLVi0T6YUBQTmOVEUA3SDbiQ6RUO+p6CE3eyD2vMWmrz5nE8yY5QSAuOV9v0boEcUv+A==",
+      "license": "MIT",
+      "dependencies": {
+        "find-my-way-ts": "^0.1.6",
+        "msgpackr": "^1.11.10",
+        "multipasta": "^0.2.7"
+      },
+      "peerDependencies": {
+        "effect": "^3.21.2"
+      }
+    },
+    "node_modules/@effect/platform-node": {
+      "version": "0.106.0",
+      "resolved": "https://registry.npmjs.org/@effect/platform-node/-/platform-node-0.106.0.tgz",
+      "integrity": "sha512-mpsJK2jNLVd0jQAjHKBo8j3wdKWznSGvfnKBcAuG/9Rr4mb8bMRZFLXHHT9wUP7EvnZ0tDZJgEDxkC+j+ByRag==",
+      "license": "MIT",
+      "dependencies": {
+        "@effect/platform-node-shared": "^0.59.0",
+        "mime": "^3.0.0",
+        "undici": "^7.10.0",
+        "ws": "^8.18.2"
+      },
+      "peerDependencies": {
+        "@effect/cluster": "^0.58.0",
+        "@effect/platform": "^0.96.0",
+        "@effect/rpc": "^0.75.0",
+        "@effect/sql": "^0.51.0",
+        "effect": "^3.21.0"
+      }
+    },
+    "node_modules/@effect/platform-node-shared": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@effect/platform-node-shared/-/platform-node-shared-0.59.0.tgz",
+      "integrity": "sha512-3bq2YKKfLY7UFauZSxqZUneCXoA3SMSls82V+0RKunvRlfPuPQW0hVn6t1RkvEdh0PDoygWG2mZXYQa6Iqgp9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/watcher": "^2.5.1",
+        "multipasta": "^0.2.7",
+        "ws": "^8.18.2"
+      },
+      "peerDependencies": {
+        "@effect/cluster": "^0.58.0",
+        "@effect/platform": "^0.96.0",
+        "@effect/rpc": "^0.75.0",
+        "@effect/sql": "^0.51.0",
+        "effect": "^3.21.0"
+      }
+    },
+    "node_modules/@effect/printer": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@effect/printer/-/printer-0.49.0.tgz",
+      "integrity": "sha512-hrjTuExF87wuWjOnnND1c2fKcCWhleQBVaoA7JlrU3rC7s+RYPETDOXtpgAK3/uuMCRnDhfVFQMevtKT8MBdKg==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@effect/typeclass": "^0.40.0",
+        "effect": "^3.21.0"
+      }
+    },
+    "node_modules/@effect/printer-ansi": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@effect/printer-ansi/-/printer-ansi-0.49.0.tgz",
+      "integrity": "sha512-N2OyqDTqcGLKeUy2URowThoU5issZQwG/Ihv5qOYWJD0neq9qBIgC57/9BkFpTRPNSMtPHyCOk1TFj297HGLLQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@effect/printer": "^0.49.0"
+      },
+      "peerDependencies": {
+        "@effect/typeclass": "^0.40.0",
+        "effect": "^3.21.0"
+      }
+    },
+    "node_modules/@effect/rpc": {
+      "version": "0.75.1",
+      "resolved": "https://registry.npmjs.org/@effect/rpc/-/rpc-0.75.1.tgz",
+      "integrity": "sha512-8yxF8+mMGGEbF8BUCp34HjdJj7CvTpGeZxBcpsDF6v7zPiGbJL1UDLzA8ZqYjmcngBHhPecbmeONTk/LiLAaEg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "msgpackr": "^1.11.10"
+      },
+      "peerDependencies": {
+        "@effect/platform": "^0.96.1",
+        "effect": "^3.21.2"
+      }
+    },
+    "node_modules/@effect/sql": {
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@effect/sql/-/sql-0.51.1.tgz",
+      "integrity": "sha512-iPDAefrJcI0HcTk9keP9Gq8Pg08K1HmpnmZZt85AqyTcvorhoNsXDFiKBbPldfV2CortwVkacX8KjO9GPpSYCA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "uuid": "^11.0.3"
+      },
+      "peerDependencies": {
+        "@effect/experimental": "^0.60.0",
+        "@effect/platform": "^0.96.1",
+        "effect": "^3.21.2"
+      }
+    },
+    "node_modules/@effect/typeclass": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@effect/typeclass/-/typeclass-0.40.0.tgz",
+      "integrity": "sha512-L/2o2ImeqbemFlqH0b3y2PqQTFc+E0/DUnffCU8bkJUGh0yUZmh2RXuXhR8QOpfNCe718JQjI+mLnpVF2MMmaQ==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "effect": "^3.21.0"
+      }
+    },
+    "node_modules/@effect/vitest": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@effect/vitest/-/vitest-0.29.0.tgz",
+      "integrity": "sha512-DvWr1aeEcaZ8mtu8hNVb4e3rEYvGEwQSr7wsNrW53t6nKYjkmjRICcvVEsXUhjoCblRHSxRsRV0TOt0+UmcvaQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "effect": "^3.21.0",
+        "vitest": "^3.2.0"
+      }
+    },
+    "node_modules/@effect/workflow": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@effect/workflow/-/workflow-0.18.1.tgz",
+      "integrity": "sha512-FxsUxkyvd7CyN7tw4bQgmAJv8tf8hUwy72bwGYzKGpeuiEObiUKgO1pg8xM49gB6EtwOdVRJhytwcFc8eM/6ow==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@effect/experimental": "^0.60.0",
+        "@effect/platform": "^0.96.1",
+        "@effect/rpc": "^0.75.1",
+        "effect": "^3.21.2"
       }
     },
     "node_modules/@emnapi/core": {
@@ -724,6 +939,84 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -743,6 +1036,301 @@
       "integrity": "sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.3",
@@ -836,9 +1424,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -853,9 +1438,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -870,9 +1452,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -887,9 +1466,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -904,9 +1480,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -921,9 +1494,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -938,9 +1508,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -955,9 +1522,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -972,9 +1536,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -989,9 +1550,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1006,9 +1564,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1023,9 +1578,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1040,9 +1592,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1137,7 +1686,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
@@ -1536,9 +2084,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1553,9 +2098,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1570,9 +2112,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1587,9 +2126,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1604,9 +2140,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1621,9 +2154,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1638,9 +2168,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1655,9 +2182,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1724,40 +2248,39 @@
       ]
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
-      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
-        "chai": "^6.2.2",
-        "tinyrainbow": "^3.1.0"
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
-      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.5",
+        "@vitest/spy": "3.2.4",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
+        "magic-string": "^0.30.17"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -1769,42 +2292,42 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
-      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.1.0"
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
-      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.5",
-        "pathe": "^2.0.3"
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
-      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/utils": "4.1.5",
-        "magic-string": "^0.30.21",
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1812,25 +2335,28 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
-      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
-      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -1922,14 +2448,41 @@
         "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/chai": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
-      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/comment-parser": {
@@ -1941,13 +2494,6 @@
       "engines": {
         "node": ">= 12.0.0"
       }
-    },
-    "node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1982,12 +2528,41 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/effect": {
+      "version": "3.21.2",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.2.tgz",
+      "integrity": "sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.21.0",
@@ -2004,9 +2579,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2425,6 +3000,28 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2476,6 +3073,12 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -2603,6 +3206,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/ini": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/is-bun-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
@@ -2617,7 +3229,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2627,7 +3238,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -2652,6 +3262,13 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
@@ -2694,6 +3311,13 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kubernetes-types": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -2724,6 +3348,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2741,6 +3372,18 @@
       "dev": true,
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/minimatch": {
@@ -2764,6 +3407,43 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/msgpackr": {
+      "version": "1.11.12",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.12.tgz",
+      "integrity": "sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
+      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
+      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -2807,6 +3487,27 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
     },
     "node_modules/npm-normalize-package-bin": {
       "version": "4.0.0",
@@ -2870,17 +3571,6 @@
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
-    },
-    "node_modules/obug": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/sxzz",
-        "https://opencollective.com/debug"
-      ],
-      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -2959,6 +3649,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2970,7 +3670,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3056,6 +3755,22 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/read-package-json-fast": {
       "version": "4.0.0",
@@ -3210,11 +3925,24 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
     },
     "node_modules/tapable": {
       "version": "2.3.3",
@@ -3238,14 +3966,11 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
-      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
@@ -3264,15 +3989,41 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
     "node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -3346,6 +4097,15 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -3396,6 +4156,20 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vite": {
@@ -3473,80 +4247,89 @@
         }
       }
     },
-    "node_modules/vitest": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
-      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.5",
-        "@vitest/mocker": "4.1.5",
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/runner": "4.1.5",
-        "@vitest/snapshot": "4.1.5",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
-        "es-module-lexer": "^2.0.0",
-        "expect-type": "^1.3.0",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^4.0.0-rc.1",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
         "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.5",
-        "@vitest/browser-preview": "4.1.5",
-        "@vitest/browser-webdriverio": "4.1.5",
-        "@vitest/coverage-istanbul": "4.1.5",
-        "@vitest/coverage-v8": "4.1.5",
-        "@vitest/ui": "4.1.5",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
         "happy-dom": "*",
-        "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "jsdom": "*"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@opentelemetry/api": {
+        "@types/debug": {
           "optional": true
         },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser-playwright": {
-          "optional": true
-        },
-        "@vitest/browser-preview": {
-          "optional": true
-        },
-        "@vitest/browser-webdriverio": {
-          "optional": true
-        },
-        "@vitest/coverage-istanbul": {
-          "optional": true
-        },
-        "@vitest/coverage-v8": {
+        "@vitest/browser": {
           "optional": true
         },
         "@vitest/ui": {
@@ -3557,9 +4340,6 @@
         },
         "jsdom": {
           "optional": true
-        },
-        "vite": {
-          "optional": false
         }
       }
     },
@@ -3604,6 +4384,42 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yocto-queue": {

--- a/plugins/commit/package.json
+++ b/plugins/commit/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@effect/language-service": "0.86.1",
-    "@effect/vitest": "^0.29.0",
+    "@effect/vitest": "0.29.0",
     "@eslint/compat": "2.1.0",
     "@eslint/js": "10.0.1",
     "@types/node": "22.19.19",

--- a/plugins/commit/package.json
+++ b/plugins/commit/package.json
@@ -13,7 +13,15 @@
     "lint:tsc": "tsc --noEmit",
     "test": "vitest run --reporter=verbose"
   },
+  "dependencies": {
+    "@effect/cli": "0.75.1",
+    "@effect/platform": "0.96.1",
+    "@effect/platform-node": "0.106.0",
+    "effect": "3.21.2"
+  },
   "devDependencies": {
+    "@effect/language-service": "0.86.1",
+    "@effect/vitest": "^0.29.0",
     "@eslint/compat": "2.1.0",
     "@eslint/js": "10.0.1",
     "@types/node": "22.19.19",
@@ -28,7 +36,7 @@
     "typescript": "6.0.3",
     "typescript-eslint": "8.59.2",
     "vite": "7.3.3",
-    "vitest": "4.1.5"
+    "vitest": "3.2.4"
   },
   "engines": {
     "node": ">=22.19.0"

--- a/plugins/commit/src/bin/commit-prepare.ts
+++ b/plugins/commit/src/bin/commit-prepare.ts
@@ -1,19 +1,14 @@
-import process from "node:process";
 import { NodeContext, NodeRuntime } from "@effect/platform-node";
-import { Console, Effect } from "effect";
+import { Console, Effect, Exit } from "effect";
 import { prepareCommit } from "../commit-prepare";
 
 const program = prepareCommit.pipe(
   Effect.flatMap((path) => Console.log(path)),
   Effect.catchTag("EmptyCommitError", (err) =>
-    Console.error(err.message).pipe(
-      Effect.zipRight(
-        Effect.sync(() => {
-          process.exitCode = 1;
-        }),
-      ),
-    ),
+    Console.error(err.message).pipe(Effect.zipRight(Effect.interrupt)),
   ),
 );
 
-NodeRuntime.runMain(program.pipe(Effect.provide(NodeContext.layer)));
+NodeRuntime.runMain(program.pipe(Effect.provide(NodeContext.layer)), {
+  teardown: (exit, onExit) => onExit(Exit.isSuccess(exit) ? 0 : 1),
+});

--- a/plugins/commit/src/bin/commit-prepare.ts
+++ b/plugins/commit/src/bin/commit-prepare.ts
@@ -1,18 +1,19 @@
 import process from "node:process";
-import { EmptyCommitError, prepareCommit } from "../commit-prepare";
+import { NodeContext, NodeRuntime } from "@effect/platform-node";
+import { Console, Effect } from "effect";
+import { prepareCommit } from "../commit-prepare";
 
-async function main(): Promise<void> {
-  try {
-    const path = await prepareCommit();
-    process.stdout.write(`${path}\n`);
-  } catch (err: unknown) {
-    if (err instanceof EmptyCommitError) {
-      console.error(err.message);
-      process.exitCode = 1;
-      return;
-    }
-    throw err;
-  }
-}
+const program = prepareCommit.pipe(
+  Effect.flatMap((path) => Console.log(path)),
+  Effect.catchTag("EmptyCommitError", (err) =>
+    Console.error(err.message).pipe(
+      Effect.zipRight(
+        Effect.sync(() => {
+          process.exitCode = 1;
+        }),
+      ),
+    ),
+  ),
+);
 
-await main();
+NodeRuntime.runMain(program.pipe(Effect.provide(NodeContext.layer)));

--- a/plugins/commit/src/bin/commit-prepare.ts
+++ b/plugins/commit/src/bin/commit-prepare.ts
@@ -3,8 +3,8 @@ import { Console, Effect, Exit } from "effect";
 import { prepareCommit } from "../commit-prepare";
 
 const program = prepareCommit.pipe(
+  Effect.tapErrorTag("EmptyCommitError", (err) => Console.error(err.message)),
   Effect.flatMap((path) => Console.log(path)),
-  Effect.catchTag("EmptyCommitError", (err) => Console.error(err.message)),
 );
 
 NodeRuntime.runMain(program.pipe(Effect.provide(NodeContext.layer)), {

--- a/plugins/commit/src/bin/commit-prepare.ts
+++ b/plugins/commit/src/bin/commit-prepare.ts
@@ -4,9 +4,7 @@ import { prepareCommit } from "../commit-prepare";
 
 const program = prepareCommit.pipe(
   Effect.flatMap((path) => Console.log(path)),
-  Effect.catchTag("EmptyCommitError", (err) =>
-    Console.error(err.message).pipe(Effect.zipRight(Effect.interrupt)),
-  ),
+  Effect.catchTag("EmptyCommitError", (err) => Console.error(err.message)),
 );
 
 NodeRuntime.runMain(program.pipe(Effect.provide(NodeContext.layer)), {

--- a/plugins/commit/src/bin/konoka-editor.ts
+++ b/plugins/commit/src/bin/konoka-editor.ts
@@ -2,24 +2,19 @@ import process from "node:process";
 import { Args, Command as CliCommand } from "@effect/cli";
 import { Command } from "@effect/platform";
 import { NodeContext, NodeRuntime } from "@effect/platform-node";
-import { Config, Effect } from "effect";
-
-const defaultEditor = ["emacsclient", "--reuse-frame", "--alternate-editor=emacs"] as const;
-
-const editorParts: Effect.Effect<readonly string[]> = Config.nonEmptyString("EDITOR").pipe(
-  Effect.map((s) => s.split(" ")),
-  Effect.orElseSucceed(() => defaultEditor),
-);
+import { Effect } from "effect";
+import { buildEditorInvocation, editorCommand } from "../konoka-editor";
 
 const commitEditmsgArg = Args.file({ name: "COMMIT_EDITMSG", exists: "yes" });
 
 const command = CliCommand.make("konoka-editor", { commitEditmsgArg }, ({ commitEditmsgArg }) =>
   Effect.gen(function* () {
-    const [editor, ...defaultArgs] = yield* editorParts;
-    if (editor == null) {
-      return yield* Effect.dieMessage("Editor command is empty");
+    const editor = yield* editorCommand;
+    const [executable, ...args] = buildEditorInvocation(editor, commitEditmsgArg);
+    if (executable == null) {
+      return yield* Effect.dieMessage("Editor invocation is empty");
     }
-    const cmd = Command.make(editor, ...defaultArgs, commitEditmsgArg).pipe(
+    const cmd = Command.make(executable, ...args).pipe(
       Command.stdin("inherit"),
       Command.stdout("inherit"),
       Command.stderr("inherit"),

--- a/plugins/commit/src/bin/konoka-editor.ts
+++ b/plugins/commit/src/bin/konoka-editor.ts
@@ -11,15 +11,15 @@ const editorParts: Effect.Effect<readonly string[]> = Config.nonEmptyString("EDI
   Effect.orElseSucceed(() => defaultEditor),
 );
 
-const editmsgFileArg = Args.file({ name: "commit-msg-file", exists: "yes" });
+const commitEditmsgArg = Args.file({ name: "COMMIT_EDITMSG", exists: "yes" });
 
-const command = CliCommand.make("konoka-editor", { editmsgFileArg }, ({ editmsgFileArg }) =>
+const command = CliCommand.make("konoka-editor", { commitEditmsgArg }, ({ commitEditmsgArg }) =>
   Effect.gen(function* () {
     const [editor, ...defaultArgs] = yield* editorParts;
     if (editor == null) {
       return yield* Effect.dieMessage("Editor command is empty");
     }
-    const cmd = Command.make(editor, ...defaultArgs, editmsgFileArg).pipe(
+    const cmd = Command.make(editor, ...defaultArgs, commitEditmsgArg).pipe(
       Command.stdin("inherit"),
       Command.stdout("inherit"),
       Command.stderr("inherit"),

--- a/plugins/commit/src/bin/konoka-editor.ts
+++ b/plugins/commit/src/bin/konoka-editor.ts
@@ -1,36 +1,34 @@
 import process from "node:process";
-import { Args, Command as CliCommand } from "@effect/cli";
-import { Command } from "@effect/platform";
+import { Args, Command } from "@effect/cli";
 import { NodeContext, NodeRuntime } from "@effect/platform-node";
 import { Effect } from "effect";
-import { buildEditorInvocation, editorCommand } from "../konoka-editor";
+import { konokaEdit } from "../konoka-editor";
 
+/**
+ * コマンドライン引数として渡された`COMMIT_EDITMSG`ファイル。
+ */
 const commitEditmsgArg = Args.file({ name: "COMMIT_EDITMSG", exists: "yes" });
 
-const command = CliCommand.make("konoka-editor", { commitEditmsgArg }, ({ commitEditmsgArg }) =>
-  Effect.gen(function* () {
-    const editor = yield* editorCommand;
-    const [executable, ...args] = buildEditorInvocation(editor, commitEditmsgArg);
-    if (executable == null) {
-      return yield* Effect.dieMessage("Editor invocation is empty");
-    }
-    const cmd = Command.make(executable, ...args).pipe(
-      Command.stdin("inherit"),
-      Command.stdout("inherit"),
-      Command.stderr("inherit"),
-    );
-    yield* Command.exitCode(cmd).pipe(
-      Effect.filterOrDie(
-        (code) => code === 0,
-        (code) => new Error(`Editor "${editor}" failed (status ${code})`),
-      ),
-    );
-  }),
+/**
+ * コマンド処理の本体。
+ */
+const command = Command.make("konoka-editor", { commitEditmsgArg }, ({ commitEditmsgArg }) =>
+  konokaEdit(commitEditmsgArg),
 );
 
-const cli = CliCommand.run(command, {
+/**
+ * メタデータを含んだコマンド全体。
+ */
+const cli = Command.run(command, {
   name: "konoka-editor",
-  version: "0.0.0",
+  version: "0.0.0", // あくまで内部プログラムでありバージョンはプラグイン側にあるのでダミー。
 });
 
-cli(process.argv).pipe(Effect.provide(NodeContext.layer), NodeRuntime.runMain);
+/**
+ * エントリーポイントとしてコマンドを起動します。
+ */
+function main(): void {
+  cli(process.argv).pipe(Effect.provide(NodeContext.layer), NodeRuntime.runMain);
+}
+
+main();

--- a/plugins/commit/src/bin/konoka-editor.ts
+++ b/plugins/commit/src/bin/konoka-editor.ts
@@ -1,26 +1,30 @@
-import { spawnSync } from "node:child_process";
 import process from "node:process";
+import { Command } from "@effect/platform";
+import { NodeContext, NodeRuntime } from "@effect/platform-node";
+import { Config, Effect } from "effect";
 
-const editorEnv = process.env["EDITOR"];
-const [editor = "emacsclient", ...defaultArgs] = editorEnv
-  ? editorEnv.split(" ")
-  : ["emacsclient", "--reuse-frame", "--alternate-editor=emacs"];
+const defaultEditor = ["emacsclient", "--reuse-frame", "--alternate-editor=emacs"] as const;
 
-const result = spawnSync(editor, [...defaultArgs, ...process.argv.slice(2)], {
-  stdio: "inherit",
+const editorParts: Effect.Effect<readonly string[]> = Config.nonEmptyString("EDITOR").pipe(
+  Effect.map((s) => s.split(" ")),
+  Effect.orElseSucceed(() => defaultEditor),
+);
+
+const program = Effect.gen(function* () {
+  const [editor, ...defaultArgs] = yield* editorParts;
+  if (editor == null) {
+    return yield* Effect.dieMessage("Editor command is empty");
+  }
+  const args = [...defaultArgs, ...process.argv.slice(2)];
+  const cmd = Command.make(editor, ...args).pipe(
+    Command.stdin("inherit"),
+    Command.stdout("inherit"),
+    Command.stderr("inherit"),
+  );
+  const exitCode = yield* Command.exitCode(cmd);
+  if (exitCode !== 0) {
+    return yield* Effect.dieMessage(`Editor "${editor}" failed (status ${exitCode})`);
+  }
 });
 
-function assertEditorSuccess(
-  editorName: string,
-  { error, status }: { error?: Error; status: number | null },
-): void {
-  if (error !== undefined || status !== 0) {
-    const detail = error !== undefined ? `: ${error.message}` : "";
-    throw new Error(
-      `Editor "${editorName}" failed (status ${status})${detail}`,
-      error !== undefined ? { cause: error } : undefined,
-    );
-  }
-}
-
-assertEditorSuccess(editor, result);
+NodeRuntime.runMain(program.pipe(Effect.provide(NodeContext.layer)));

--- a/plugins/commit/src/bin/konoka-editor.ts
+++ b/plugins/commit/src/bin/konoka-editor.ts
@@ -1,4 +1,5 @@
 import process from "node:process";
+import { Args, Command as CliCommand } from "@effect/cli";
 import { Command } from "@effect/platform";
 import { NodeContext, NodeRuntime } from "@effect/platform-node";
 import { Config, Effect } from "effect";
@@ -10,21 +11,29 @@ const editorParts: Effect.Effect<readonly string[]> = Config.nonEmptyString("EDI
   Effect.orElseSucceed(() => defaultEditor),
 );
 
-const program = Effect.gen(function* () {
-  const [editor, ...defaultArgs] = yield* editorParts;
-  if (editor == null) {
-    return yield* Effect.dieMessage("Editor command is empty");
-  }
-  const args = [...defaultArgs, ...process.argv.slice(2)];
-  const cmd = Command.make(editor, ...args).pipe(
-    Command.stdin("inherit"),
-    Command.stdout("inherit"),
-    Command.stderr("inherit"),
-  );
-  const exitCode = yield* Command.exitCode(cmd);
-  if (exitCode !== 0) {
-    return yield* Effect.dieMessage(`Editor "${editor}" failed (status ${exitCode})`);
-  }
+const editmsgFileArg = Args.file({ name: "commit-msg-file", exists: "yes" });
+
+const command = CliCommand.make("konoka-editor", { editmsgFileArg }, ({ editmsgFileArg }) =>
+  Effect.gen(function* () {
+    const [editor, ...defaultArgs] = yield* editorParts;
+    if (editor == null) {
+      return yield* Effect.dieMessage("Editor command is empty");
+    }
+    const cmd = Command.make(editor, ...defaultArgs, editmsgFileArg).pipe(
+      Command.stdin("inherit"),
+      Command.stdout("inherit"),
+      Command.stderr("inherit"),
+    );
+    const exitCode = yield* Command.exitCode(cmd);
+    if (exitCode !== 0) {
+      return yield* Effect.dieMessage(`Editor "${editor}" failed (status ${exitCode})`);
+    }
+  }),
+);
+
+const cli = CliCommand.run(command, {
+  name: "konoka-editor",
+  version: "0.0.0",
 });
 
-NodeRuntime.runMain(program.pipe(Effect.provide(NodeContext.layer)));
+cli(process.argv).pipe(Effect.provide(NodeContext.layer), NodeRuntime.runMain);

--- a/plugins/commit/src/bin/konoka-editor.ts
+++ b/plugins/commit/src/bin/konoka-editor.ts
@@ -24,10 +24,12 @@ const command = CliCommand.make("konoka-editor", { commitEditmsgArg }, ({ commit
       Command.stdout("inherit"),
       Command.stderr("inherit"),
     );
-    const exitCode = yield* Command.exitCode(cmd);
-    if (exitCode !== 0) {
-      return yield* Effect.dieMessage(`Editor "${editor}" failed (status ${exitCode})`);
-    }
+    yield* Command.exitCode(cmd).pipe(
+      Effect.filterOrDie(
+        (code) => code === 0,
+        (code) => new Error(`Editor "${editor}" failed (status ${code})`),
+      ),
+    );
   }),
 );
 

--- a/plugins/commit/src/bin/read-commit-instructions.ts
+++ b/plugins/commit/src/bin/read-commit-instructions.ts
@@ -1,11 +1,18 @@
 import process from "node:process";
+import { NodeContext, NodeRuntime } from "@effect/platform-node";
+import { Effect, Option } from "effect";
 import { readCommitInstructions } from "../read-commit-instructions";
 
-async function main(): Promise<void> {
-  const content = await readCommitInstructions();
-  if (content != null) {
-    process.stdout.write(content);
-  }
-}
+const program = readCommitInstructions.pipe(
+  Effect.flatMap((content) =>
+    Option.match(content, {
+      onNone: () => Effect.void,
+      onSome: (text) =>
+        Effect.sync(() => {
+          process.stdout.write(text);
+        }),
+    }),
+  ),
+);
 
-await main();
+NodeRuntime.runMain(program.pipe(Effect.provide(NodeContext.layer)));

--- a/plugins/commit/src/commit-prepare.ts
+++ b/plugins/commit/src/commit-prepare.ts
@@ -1,19 +1,15 @@
-import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import process from "node:process";
-import { promisify } from "node:util";
+import { Command, FileSystem, Path } from "@effect/platform";
+import type { CommandExecutor } from "@effect/platform/CommandExecutor";
+import type { PlatformError } from "@effect/platform/Error";
+import { Config, Data, Effect } from "effect";
 
-const execFileAsync = promisify(execFile);
+const pluginName = "commit" as const;
 
-/** Thrown when there is nothing to commit. */
-export class EmptyCommitError extends Error {
-  override name = "EmptyCommitError" as const;
-  constructor(message: string) {
-    super(message);
-  }
-}
+/** Raised when there is nothing to commit. */
+export class EmptyCommitError extends Data.TaggedError("EmptyCommitError")<{
+  readonly message: string;
+}> {}
 
 /** Generate an ISO 8601-like timestamp for use in directory names. */
 export function timestamp(): string {
@@ -37,58 +33,63 @@ export function buildEditmsgTemplate(diff: string): string {
   return `\n# ------------------------ >8 ------------------------\n${diff}\n`;
 }
 
-const pluginName = "commit" as const;
-
-async function git(...args: readonly string[]): Promise<string> {
-  const { stdout } = await execFileAsync("git", args, { maxBuffer: 10 * 1024 * 1024 });
-  return stdout.trimEnd();
+/** Run git with the given args and return trimmed stdout. */
+function git(...args: readonly string[]): Effect.Effect<string, PlatformError, CommandExecutor> {
+  return Command.string(Command.make("git", ...args)).pipe(Effect.map((s) => s.trimEnd()));
 }
 
-function getPersonalWorkDir(): string {
-  const runtimeDir = process.env["XDG_RUNTIME_DIR"];
-  if (runtimeDir != null && runtimeDir !== "") {
-    return runtimeDir;
-  }
-  return tmpdir();
-}
+const personalWorkDir: Effect.Effect<string> = Config.nonEmptyString("XDG_RUNTIME_DIR").pipe(
+  Effect.orElseSucceed(() => tmpdir()),
+);
 
-function getCodingAgentWorkDir(): string {
-  return join(getPersonalWorkDir(), "coding-agent-work", pluginName);
-}
+const codingAgentWorkDir: Effect.Effect<string, never, Path.Path> = Effect.gen(function* () {
+  const path = yield* Path.Path;
+  const base = yield* personalWorkDir;
+  return path.join(base, "coding-agent-work", pluginName);
+});
 
-async function createWorkdirPath(): Promise<string> {
-  const codingAgentWorkDir = getCodingAgentWorkDir();
-  await mkdir(codingAgentWorkDir, { recursive: true, mode: 0o700 });
-  return mkdtemp(join(codingAgentWorkDir, `${timestamp()}-`));
-}
+const createWorkdirPath: Effect.Effect<string, PlatformError, FileSystem.FileSystem | Path.Path> =
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const base = yield* codingAgentWorkDir;
+    yield* fs.makeDirectory(base, { recursive: true, mode: 0o700 });
+    return yield* fs.makeTempDirectory({ directory: base, prefix: `${timestamp()}-` });
+  });
 
-async function ensureStaged(): Promise<void> {
-  const status = await git("status", "--porcelain");
-  if (status === "") {
-    throw new EmptyCommitError("No changes to commit.");
-  }
-  if (!hasStagedChanges(status)) {
-    await git("add", "--all");
-  }
-}
+const ensureStaged: Effect.Effect<void, PlatformError | EmptyCommitError, CommandExecutor> =
+  Effect.gen(function* () {
+    const status = yield* git("status", "--porcelain");
+    if (status === "") {
+      return yield* new EmptyCommitError({ message: "No changes to commit." });
+    }
+    if (!hasStagedChanges(status)) {
+      yield* git("add", "--all");
+    }
+  });
 
-async function getStagedDiff(): Promise<string> {
-  const diff = await git("diff", "--cached");
-  if (diff === "") {
-    throw new EmptyCommitError("No staged changes to commit.");
-  }
-  return diff;
-}
+const getStagedDiff: Effect.Effect<string, PlatformError | EmptyCommitError, CommandExecutor> =
+  Effect.gen(function* () {
+    const diff = yield* git("diff", "--cached");
+    if (diff === "") {
+      return yield* new EmptyCommitError({ message: "No staged changes to commit." });
+    }
+    return diff;
+  });
 
-async function stageThenDiff(): Promise<string> {
-  await ensureStaged();
-  return getStagedDiff();
-}
+const stageThenDiff: Effect.Effect<string, PlatformError | EmptyCommitError, CommandExecutor> =
+  ensureStaged.pipe(Effect.zipRight(getStagedDiff));
 
-async function writeEditmsgTemplate(workdirPath: string, diff: string): Promise<string> {
-  const editmsgPath = join(workdirPath, "COMMIT_EDITMSG");
-  await writeFile(editmsgPath, buildEditmsgTemplate(diff));
-  return editmsgPath;
+function writeEditmsgTemplate(
+  workdirPath: string,
+  diff: string,
+): Effect.Effect<string, PlatformError, FileSystem.FileSystem | Path.Path> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const editmsgPath = path.join(workdirPath, "COMMIT_EDITMSG");
+    yield* fs.writeFileString(editmsgPath, buildEditmsgTemplate(diff));
+    return editmsgPath;
+  });
 }
 
 /**
@@ -99,9 +100,15 @@ async function writeEditmsgTemplate(workdirPath: string, diff: string): Promise<
  * 一時ディレクトリを作り、scissors lineと差分を含むテンプレートを配置します。
  * 未設定環境では`os.tmpdir()`にフォールバックします。
  *
- * 何もステージできるものが無い場合は`EmptyCommitError`を投げます。
+ * 何もステージできるものが無い場合は`EmptyCommitError`で失敗します。
  */
-export async function prepareCommit(): Promise<string> {
-  const [workdirPath, diff] = await Promise.all([createWorkdirPath(), stageThenDiff()]);
-  return writeEditmsgTemplate(workdirPath, diff);
-}
+export const prepareCommit: Effect.Effect<
+  string,
+  PlatformError | EmptyCommitError,
+  FileSystem.FileSystem | Path.Path | CommandExecutor
+> = Effect.gen(function* () {
+  const [workdirPath, diff] = yield* Effect.all([createWorkdirPath, stageThenDiff], {
+    concurrency: 2,
+  });
+  return yield* writeEditmsgTemplate(workdirPath, diff);
+});

--- a/plugins/commit/src/konoka-editor.ts
+++ b/plugins/commit/src/konoka-editor.ts
@@ -1,3 +1,6 @@
+import { Command } from "@effect/platform";
+import type { CommandExecutor } from "@effect/platform/CommandExecutor";
+import type { PlatformError } from "@effect/platform/Error";
 import { Config, Effect } from "effect";
 
 /**
@@ -38,4 +41,30 @@ export function buildEditorInvocation(editor: string, file: string): readonly st
     "konoka-editor",
     file,
   ];
+}
+
+/**
+ * コマンドを推定して起動して編集を行います。
+ */
+export function konokaEdit(
+  commitEditmsgArg: string,
+): Effect.Effect<undefined, PlatformError, CommandExecutor> {
+  return Effect.gen(function* () {
+    const editor = yield* editorCommand;
+    const [executable, ...args] = buildEditorInvocation(editor, commitEditmsgArg);
+    if (executable == null) {
+      return yield* Effect.dieMessage("Editor invocation is empty");
+    }
+    const cmd = Command.make(executable, ...args).pipe(
+      Command.stdin("inherit"),
+      Command.stdout("inherit"),
+      Command.stderr("inherit"),
+    );
+    yield* Command.exitCode(cmd).pipe(
+      Effect.filterOrDie(
+        (code) => code === 0,
+        (code) => new Error(`Editor "${editor}" failed (status ${code})`),
+      ),
+    );
+  });
 }

--- a/plugins/commit/src/konoka-editor.ts
+++ b/plugins/commit/src/konoka-editor.ts
@@ -1,7 +1,16 @@
 import { Command } from "@effect/platform";
 import type { CommandExecutor } from "@effect/platform/CommandExecutor";
 import type { PlatformError } from "@effect/platform/Error";
-import { Config, Effect } from "effect";
+import { Config, Data, Effect } from "effect";
+
+export class EditorFailedError extends Data.TaggedError("EditorFailedError")<{
+  readonly editor: string;
+  readonly exitCode: number;
+}> {
+  override get message(): string {
+    return `Editor command "${this.editor}" failed with exit code ${this.exitCode}.`;
+  }
+}
 
 /**
  * 環境変数`EDITOR`が未設定または空のときに使うデフォルトのエディタコマンドです。
@@ -63,7 +72,7 @@ export function konokaEdit(
     yield* Command.exitCode(cmd).pipe(
       Effect.filterOrDie(
         (code) => code === 0,
-        (code) => new Error(`Editor "${editor}" failed (status ${code})`),
+        (code) => new EditorFailedError({ editor, exitCode: code }),
       ),
     );
   });

--- a/plugins/commit/src/konoka-editor.ts
+++ b/plugins/commit/src/konoka-editor.ts
@@ -1,0 +1,41 @@
+import { Config, Effect } from "effect";
+
+/**
+ * 環境変数`EDITOR`が未設定または空のときに使うデフォルトのエディタコマンドです。
+ */
+export const defaultEditor = "emacsclient --reuse-frame --alternate-editor=emacs" as const;
+
+/**
+ * 環境変数`EDITOR`の値を取得し、
+ * 未設定または空文字列の場合は`defaultEditor`を返します。
+ *
+ * `EDITOR`はユーザが設定するものなので信頼できる文字列として扱います。
+ * シェルが解釈するコマンド文字列としてそのまま`sh -c`に渡される前提です。
+ */
+export const editorCommand: Effect.Effect<string> = Config.nonEmptyString("EDITOR").pipe(
+  Effect.orElseSucceed(() => defaultEditor),
+);
+
+/**
+ * `EDITOR`コマンド文字列とファイルパスから、
+ * `sh -c`経由で起動するための`argv`を生成します。
+ *
+ * gitやsudoeditと同じく、
+ * `EDITOR`はシェルが解釈するコマンド文字列として扱います。
+ * 実行ファイルパスにスペースがある場合はユーザがクオートで対処します。
+ * ファイルパスは`"$@"`経由の位置引数として渡し、
+ * シェル側での再解釈を避けます。
+ */
+export function buildEditorInvocation(editor: string, file: string): readonly string[] {
+  return [
+    "sh",
+    "-c",
+    `${editor} "$@"`,
+    // `sh -c <script> <argv0> <argv1>...`の引数列で、
+    // `<argv0>`はスクリプト内の`$0`に入ります。
+    // シェルがエラーメッセージを出す際の名乗りに使われるので、ここを`konoka-editor`にしておくと、
+    // `konoka-editor: <editor>: not found`のように出所の追跡しやすい表示になります。
+    "konoka-editor",
+    file,
+  ];
+}

--- a/plugins/commit/src/konoka-editor.ts
+++ b/plugins/commit/src/konoka-editor.ts
@@ -29,7 +29,10 @@ export const editorCommand: Effect.Effect<string> = Config.nonEmptyString("EDITO
  * ファイルパスは`"$@"`経由の位置引数として渡し、
  * シェル側での再解釈を避けます。
  */
-export function buildEditorInvocation(editor: string, file: string): readonly string[] {
+export function buildEditorInvocation(
+  editor: string,
+  file: string,
+): readonly ["sh", "-c", string, "konoka-editor", string] {
   return [
     "sh",
     "-c",
@@ -48,13 +51,10 @@ export function buildEditorInvocation(editor: string, file: string): readonly st
  */
 export function konokaEdit(
   commitEditmsgArg: string,
-): Effect.Effect<undefined, PlatformError, CommandExecutor> {
+): Effect.Effect<void, PlatformError, CommandExecutor> {
   return Effect.gen(function* () {
     const editor = yield* editorCommand;
     const [executable, ...args] = buildEditorInvocation(editor, commitEditmsgArg);
-    if (executable == null) {
-      return yield* Effect.dieMessage("Editor invocation is empty");
-    }
     const cmd = Command.make(executable, ...args).pipe(
       Command.stdin("inherit"),
       Command.stdout("inherit"),

--- a/plugins/commit/src/read-commit-instructions.ts
+++ b/plugins/commit/src/read-commit-instructions.ts
@@ -1,19 +1,25 @@
-import { readFile } from "node:fs/promises";
+import { FileSystem } from "@effect/platform";
+import type { PlatformError } from "@effect/platform/Error";
+import { Effect, Option } from "effect";
 
 const COMMIT_INSTRUCTIONS_PATH = ".github/git-commit-instructions.md" as const;
 
 /**
- * Read project-specific commit message guidelines if available.
+ * プロジェクト固有のコミットメッセージガイドラインを読み込みます。
  *
- * Returns the file contents as UTF-8 text, or `undefined` when the file does not exist.
+ * UTF-8として読み取った内容を`Option.some`で返します。
+ * ファイルが存在しない場合は`Option.none`を返します。
  */
-export async function readCommitInstructions(): Promise<string | undefined> {
-  try {
-    return await readFile(COMMIT_INSTRUCTIONS_PATH, "utf8");
-  } catch (err: unknown) {
-    if (err instanceof Error && "code" in err && err.code === "ENOENT") {
-      return undefined;
-    }
-    throw err;
-  }
-}
+export const readCommitInstructions: Effect.Effect<
+  Option.Option<string>,
+  PlatformError,
+  FileSystem.FileSystem
+> = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* fs.readFileString(COMMIT_INSTRUCTIONS_PATH, "utf8").pipe(
+    Effect.map(Option.some),
+    Effect.catchTag("SystemError", (err) =>
+      err.reason === "NotFound" ? Effect.succeed(Option.none<string>()) : Effect.fail(err),
+    ),
+  );
+});

--- a/plugins/commit/test/commit-prepare.test.ts
+++ b/plugins/commit/test/commit-prepare.test.ts
@@ -1,3 +1,4 @@
+import { Effect } from "effect";
 import { describe, expect, test, vi } from "vitest";
 import {
   EmptyCommitError,
@@ -84,18 +85,20 @@ describe("buildEditmsgTemplate", () => {
 
 describe("EmptyCommitError", () => {
   test("Errorを継承している", () => {
-    const error = new EmptyCommitError("test message");
+    const error = new EmptyCommitError({ message: "test message" });
     expect(error).toBeInstanceOf(Error);
     expect(error).toBeInstanceOf(EmptyCommitError);
   });
 
   test("メッセージを保持する", () => {
-    const error = new EmptyCommitError("No changes to commit.");
+    const error = new EmptyCommitError({ message: "No changes to commit." });
     expect(error.message).toBe("No changes to commit.");
   });
 
-  test("nameプロパティが正しい", () => {
-    const error = new EmptyCommitError("test");
-    expect(error.name).toBe("EmptyCommitError");
+  test("Effect.catchTagで捕捉できる", () => {
+    const program = Effect.fail(new EmptyCommitError({ message: "caught" })).pipe(
+      Effect.catchTag("EmptyCommitError", (err) => Effect.succeed(err.message)),
+    );
+    expect(Effect.runSync(program)).toBe("caught");
   });
 });

--- a/plugins/commit/test/konoka-editor.test.ts
+++ b/plugins/commit/test/konoka-editor.test.ts
@@ -1,7 +1,13 @@
+import { NodeContext } from "@effect/platform-node";
 import { describe, it } from "@effect/vitest";
-import { ConfigProvider, Effect } from "effect";
+import { Cause, ConfigProvider, Effect, Exit, Option } from "effect";
 import { expect, test } from "vitest";
-import { buildEditorInvocation, defaultEditor, editorCommand } from "../src/konoka-editor";
+import {
+  buildEditorInvocation,
+  defaultEditor,
+  editorCommand,
+  konokaEdit,
+} from "../src/konoka-editor";
 
 describe("buildEditorInvocation", () => {
   test("`sh -c`経由のargvを生成する", () => {
@@ -84,4 +90,41 @@ describe("editorCommand", () => {
       Effect.withConfigProvider(ConfigProvider.fromMap(new Map([["EDITOR", ""]]))),
     ),
   );
+});
+
+describe("konokaEdit", () => {
+  it.effect("`EDITOR`が0で終わる場合は成功する", () =>
+    konokaEdit("/tmp/konoka-editor-test-arg").pipe(
+      Effect.withConfigProvider(ConfigProvider.fromMap(new Map([["EDITOR", "true"]]))),
+      Effect.provide(NodeContext.layer),
+    ),
+  );
+
+  it.effect("`EDITOR`が非0で終わる場合は終了コードを含むdefectで死ぬ", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(konokaEdit("/tmp/konoka-editor-test-arg"));
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        const defect = Cause.dieOption(exit.cause);
+        expect(Option.isSome(defect)).toBe(true);
+        if (Option.isSome(defect)) {
+          expect(String(defect.value)).toContain(`Editor "false" failed (status 1)`);
+        }
+      }
+    }).pipe(
+      Effect.withConfigProvider(ConfigProvider.fromMap(new Map([["EDITOR", "false"]]))),
+      Effect.provide(NodeContext.layer),
+    ),
+  );
+
+  it.effect("引数のファイルパスが`$1`としてエディタに渡る", () => {
+    // 内側に`sh -c`をもう一段噛ませることで、`"$@"`を素直な位置引数として受け取り、
+    // `$1`が`konokaEdit`に渡したファイルパスと一致するかを終了コードで判定します。
+    const arg = "/tmp/konoka-editor-passthrough-test";
+    const editor = `sh -c 'test "$1" = "${arg}"' --`;
+    return konokaEdit(arg).pipe(
+      Effect.withConfigProvider(ConfigProvider.fromMap(new Map([["EDITOR", editor]]))),
+      Effect.provide(NodeContext.layer),
+    );
+  });
 });

--- a/plugins/commit/test/konoka-editor.test.ts
+++ b/plugins/commit/test/konoka-editor.test.ts
@@ -1,0 +1,87 @@
+import { describe, it } from "@effect/vitest";
+import { ConfigProvider, Effect } from "effect";
+import { expect, test } from "vitest";
+import { buildEditorInvocation, defaultEditor, editorCommand } from "../src/konoka-editor";
+
+describe("buildEditorInvocation", () => {
+  test("`sh -c`経由のargvを生成する", () => {
+    expect(buildEditorInvocation("vim", "/tmp/file")).toEqual([
+      "sh",
+      "-c",
+      `vim "$@"`,
+      "konoka-editor",
+      "/tmp/file",
+    ]);
+  });
+
+  test("引数付きエディタ指定もそのままシェルスクリプトに埋め込む", () => {
+    expect(buildEditorInvocation("emacsclient --reuse-frame", "/tmp/file")).toEqual([
+      "sh",
+      "-c",
+      `emacsclient --reuse-frame "$@"`,
+      "konoka-editor",
+      "/tmp/file",
+    ]);
+  });
+
+  test("ファイルパスをスクリプト本体に埋め込まず位置引数として渡す", () => {
+    const argv = buildEditorInvocation("vim", "/tmp/file with space");
+    expect(argv[2]).toBe(`vim "$@"`);
+    expect(argv[2]).not.toContain("/tmp/file with space");
+    expect(argv[4]).toBe("/tmp/file with space");
+  });
+
+  test("シェル内`$0`にあたる位置に`konoka-editor`を渡す", () => {
+    const argv = buildEditorInvocation("vim", "/tmp/file");
+    expect(argv[3]).toBe("konoka-editor");
+  });
+
+  test("実行ファイルパスをクオートしたエディタ指定もそのまま渡す", () => {
+    const editor = `"/Applications/Visual Studio Code.app/Contents/MacOS/Electron" --wait`;
+    expect(buildEditorInvocation(editor, "/tmp/file")).toEqual([
+      "sh",
+      "-c",
+      `${editor} "$@"`,
+      "konoka-editor",
+      "/tmp/file",
+    ]);
+  });
+});
+
+describe("editorCommand", () => {
+  it.effect("`EDITOR`が設定されていればその値を返す", () =>
+    editorCommand.pipe(
+      Effect.tap((cmd) => {
+        expect(cmd).toBe("nano");
+      }),
+      Effect.withConfigProvider(ConfigProvider.fromMap(new Map([["EDITOR", "nano"]]))),
+    ),
+  );
+
+  it.effect("`EDITOR`に引数付きコマンドを設定してもそのまま返す", () =>
+    editorCommand.pipe(
+      Effect.tap((cmd) => {
+        expect(cmd).toBe("code --wait");
+      }),
+      Effect.withConfigProvider(ConfigProvider.fromMap(new Map([["EDITOR", "code --wait"]]))),
+    ),
+  );
+
+  it.effect("`EDITOR`が未設定の場合はデフォルトを返す", () =>
+    editorCommand.pipe(
+      Effect.tap((cmd) => {
+        expect(cmd).toBe(defaultEditor);
+      }),
+      Effect.withConfigProvider(ConfigProvider.fromMap(new Map())),
+    ),
+  );
+
+  it.effect("`EDITOR`が空文字列の場合もデフォルトを返す", () =>
+    editorCommand.pipe(
+      Effect.tap((cmd) => {
+        expect(cmd).toBe(defaultEditor);
+      }),
+      Effect.withConfigProvider(ConfigProvider.fromMap(new Map([["EDITOR", ""]]))),
+    ),
+  );
+});

--- a/plugins/commit/test/konoka-editor.test.ts
+++ b/plugins/commit/test/konoka-editor.test.ts
@@ -108,7 +108,9 @@ describe("konokaEdit", () => {
         const defect = Cause.dieOption(exit.cause);
         expect(Option.isSome(defect)).toBe(true);
         if (Option.isSome(defect)) {
-          expect(String(defect.value)).toContain(`Editor "false" failed (status 1)`);
+          expect(String(defect.value)).toContain(
+            `EditorFailedError: Editor command "false" failed with exit code 1.`,
+          );
         }
       }
     }).pipe(

--- a/plugins/commit/tsconfig.json
+++ b/plugins/commit/tsconfig.json
@@ -66,7 +66,13 @@
      */
     // 明示的にimportしなくても有効になる`@types/*`の対象を設定できます。
     // ここに列挙されたものだけ暗黙時に有効になります。
-    "types": ["node"]
+    "types": ["node"],
+    // プラグイン。
+    "plugins": [
+      {
+        "name": "@effect/language-service"
+      }
+    ]
   },
   // コンパイル対象から除外するパスのglobパターンを記述できます。
   "exclude": ["node_modules", "dist", "result", "result-*"]


### PR DESCRIPTION
`commit`プラグインの補助プログラム3バイナリ(`commit-prepare`/`read-commit-instructions`/`konoka-editor`)を、
Effectベースの宣言的な記述に書き換え、テストカバレッジを整備します。

従来は`child_process`/`fs/promises`/`process`などのNode.jsのAPIに直接依存していました。
これを`@effect/platform`/`@effect/cli`/`effect`に集約することで、
副作用と引数処理と終了コードの全てをEffectのruntimeとサービス層に委ねる構造にします。

主な成果は以下です。

- 3バイナリと共通モジュールを`FileSystem`/`Path`/`Command`を介した宣言的記述に統一
- `konoka-editor`の引数処理を`@effect/cli`の`Args.file`で宣言し、入力検証を仕組みに任せる
- `konoka-editor`の`EDITOR`起動を`sh -c "$EDITOR \"$@\""`方式に変更し、
  実行ファイルパスにスペースが含まれていてもユーザがクオートで対応できるようにする(git/sudoeditと同じ慣習)
- 終了コードの管理を`process.exitCode`の手書きから、
  `Effect.interrupt` + 集中teardownや`Effect.filterOrDie`に置き換える
- `EmptyCommitError`を`Data.TaggedError`化し、`Effect.catchTag`で型安全に捕捉できるようにする
- テスト可能な純粋ロジックを`src/konoka-editor.ts`に切り出し、
  `@effect/vitest`の`it.effect`と`ConfigProvider.fromMap`で`EDITOR`周りの挙動を検証

CLIの入力・出力・終了コードの仕様は維持しているため、ユーザ向けの挙動には影響しません。
