### PR TITLE
refactor(pr): 補助プログラムをEffectベースの宣言的記述に書き換える

### DIFF
--- a/plugins/pr/.claude-plugin/plugin.json
+++ b/plugins/pr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pr",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Create a GitHub pull request from the current branch.",
   "author": {
     "name": "ncaq",

--- a/plugins/pr/package-lock.json
+++ b/plugins/pr/package-lock.json
@@ -5,7 +5,15 @@
   "packages": {
     "": {
       "name": "konoka-pr",
+      "dependencies": {
+        "@effect/cli": "0.75.1",
+        "@effect/platform": "0.96.1",
+        "@effect/platform-node": "0.106.0",
+        "effect": "3.21.2"
+      },
       "devDependencies": {
+        "@effect/language-service": "0.86.1",
+        "@effect/vitest": "0.29.0",
         "@eslint/compat": "2.1.0",
         "@eslint/js": "10.0.1",
         "@types/node": "22.19.19",
@@ -20,10 +28,217 @@
         "typescript": "6.0.3",
         "typescript-eslint": "8.59.2",
         "vite": "7.3.3",
-        "vitest": "4.1.5"
+        "vitest": "3.2.4"
       },
       "engines": {
         "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@effect/cli": {
+      "version": "0.75.1",
+      "resolved": "https://registry.npmjs.org/@effect/cli/-/cli-0.75.1.tgz",
+      "integrity": "sha512-aDZ1OZzaFAb6NyBOrP+Bl52eICds5ERI9aa67LzloJELt5SCWeNwthtaEacBvvMkwVUcykJ+YHcGCkD1t47g8g==",
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^4.1.3",
+        "toml": "^3.0.0",
+        "yaml": "^2.5.0"
+      },
+      "peerDependencies": {
+        "@effect/platform": "^0.96.0",
+        "@effect/printer": "^0.49.0",
+        "@effect/printer-ansi": "^0.49.0",
+        "effect": "^3.21.1"
+      }
+    },
+    "node_modules/@effect/cluster": {
+      "version": "0.58.2",
+      "resolved": "https://registry.npmjs.org/@effect/cluster/-/cluster-0.58.2.tgz",
+      "integrity": "sha512-oxQ3zUhXq0mJA7Y4TliALMP39Bx0LtAIxcqOW1Bdjh6uk+nG7kul/Puw80SwlcYGv3ul50SG+gvSRUTXB8d3JQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "kubernetes-types": "^1.30.0"
+      },
+      "peerDependencies": {
+        "@effect/platform": "^0.96.1",
+        "@effect/rpc": "^0.75.1",
+        "@effect/sql": "^0.51.1",
+        "@effect/workflow": "^0.18.0",
+        "effect": "^3.21.2"
+      }
+    },
+    "node_modules/@effect/experimental": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@effect/experimental/-/experimental-0.60.0.tgz",
+      "integrity": "sha512-i5zIg7Xup2KgHyqHlYtkgqSE1bNzCL0GbbTQxrpIzKF0q/ebknOk/ox8B/gIq2vImjoEE81h/oxU+6i1NH210g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "uuid": "^11.0.3"
+      },
+      "peerDependencies": {
+        "@effect/platform": "^0.96.0",
+        "effect": "^3.21.0",
+        "ioredis": "^5",
+        "lmdb": "^3"
+      },
+      "peerDependenciesMeta": {
+        "ioredis": {
+          "optional": true
+        },
+        "lmdb": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@effect/language-service": {
+      "version": "0.86.1",
+      "resolved": "https://registry.npmjs.org/@effect/language-service/-/language-service-0.86.1.tgz",
+      "integrity": "sha512-jfUuFdtNPKRZ4ZSrgTnfMHPIVq8L9cM+YGEylQ1lhIgNY23ZvfdPg0cUlWESd4q9aGvOWSA8E79AS0qe3j4ROw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "effect-language-service": "cli.js"
+      }
+    },
+    "node_modules/@effect/platform": {
+      "version": "0.96.1",
+      "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.96.1.tgz",
+      "integrity": "sha512-cjB1QZZYEP8JXCFNGvBLVi0T6YUBQTmOVEUA3SDbiQ6RUO+p6CE3eyD2vMWmrz5nE8yY5QSAuOV9v0boEcUv+A==",
+      "license": "MIT",
+      "dependencies": {
+        "find-my-way-ts": "^0.1.6",
+        "msgpackr": "^1.11.10",
+        "multipasta": "^0.2.7"
+      },
+      "peerDependencies": {
+        "effect": "^3.21.2"
+      }
+    },
+    "node_modules/@effect/platform-node": {
+      "version": "0.106.0",
+      "resolved": "https://registry.npmjs.org/@effect/platform-node/-/platform-node-0.106.0.tgz",
+      "integrity": "sha512-mpsJK2jNLVd0jQAjHKBo8j3wdKWznSGvfnKBcAuG/9Rr4mb8bMRZFLXHHT9wUP7EvnZ0tDZJgEDxkC+j+ByRag==",
+      "license": "MIT",
+      "dependencies": {
+        "@effect/platform-node-shared": "^0.59.0",
+        "mime": "^3.0.0",
+        "undici": "^7.10.0",
+        "ws": "^8.18.2"
+      },
+      "peerDependencies": {
+        "@effect/cluster": "^0.58.0",
+        "@effect/platform": "^0.96.0",
+        "@effect/rpc": "^0.75.0",
+        "@effect/sql": "^0.51.0",
+        "effect": "^3.21.0"
+      }
+    },
+    "node_modules/@effect/platform-node-shared": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@effect/platform-node-shared/-/platform-node-shared-0.59.0.tgz",
+      "integrity": "sha512-3bq2YKKfLY7UFauZSxqZUneCXoA3SMSls82V+0RKunvRlfPuPQW0hVn6t1RkvEdh0PDoygWG2mZXYQa6Iqgp9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/watcher": "^2.5.1",
+        "multipasta": "^0.2.7",
+        "ws": "^8.18.2"
+      },
+      "peerDependencies": {
+        "@effect/cluster": "^0.58.0",
+        "@effect/platform": "^0.96.0",
+        "@effect/rpc": "^0.75.0",
+        "@effect/sql": "^0.51.0",
+        "effect": "^3.21.0"
+      }
+    },
+    "node_modules/@effect/printer": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@effect/printer/-/printer-0.49.0.tgz",
+      "integrity": "sha512-hrjTuExF87wuWjOnnND1c2fKcCWhleQBVaoA7JlrU3rC7s+RYPETDOXtpgAK3/uuMCRnDhfVFQMevtKT8MBdKg==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@effect/typeclass": "^0.40.0",
+        "effect": "^3.21.0"
+      }
+    },
+    "node_modules/@effect/printer-ansi": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@effect/printer-ansi/-/printer-ansi-0.49.0.tgz",
+      "integrity": "sha512-N2OyqDTqcGLKeUy2URowThoU5issZQwG/Ihv5qOYWJD0neq9qBIgC57/9BkFpTRPNSMtPHyCOk1TFj297HGLLQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@effect/printer": "^0.49.0"
+      },
+      "peerDependencies": {
+        "@effect/typeclass": "^0.40.0",
+        "effect": "^3.21.0"
+      }
+    },
+    "node_modules/@effect/rpc": {
+      "version": "0.75.1",
+      "resolved": "https://registry.npmjs.org/@effect/rpc/-/rpc-0.75.1.tgz",
+      "integrity": "sha512-8yxF8+mMGGEbF8BUCp34HjdJj7CvTpGeZxBcpsDF6v7zPiGbJL1UDLzA8ZqYjmcngBHhPecbmeONTk/LiLAaEg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "msgpackr": "^1.11.10"
+      },
+      "peerDependencies": {
+        "@effect/platform": "^0.96.1",
+        "effect": "^3.21.2"
+      }
+    },
+    "node_modules/@effect/sql": {
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@effect/sql/-/sql-0.51.1.tgz",
+      "integrity": "sha512-iPDAefrJcI0HcTk9keP9Gq8Pg08K1HmpnmZZt85AqyTcvorhoNsXDFiKBbPldfV2CortwVkacX8KjO9GPpSYCA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "uuid": "^11.0.3"
+      },
+      "peerDependencies": {
+        "@effect/experimental": "^0.60.0",
+        "@effect/platform": "^0.96.1",
+        "effect": "^3.21.2"
+      }
+    },
+    "node_modules/@effect/typeclass": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@effect/typeclass/-/typeclass-0.40.0.tgz",
+      "integrity": "sha512-L/2o2ImeqbemFlqH0b3y2PqQTFc+E0/DUnffCU8bkJUGh0yUZmh2RXuXhR8QOpfNCe718JQjI+mLnpVF2MMmaQ==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "effect": "^3.21.0"
+      }
+    },
+    "node_modules/@effect/vitest": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@effect/vitest/-/vitest-0.29.0.tgz",
+      "integrity": "sha512-DvWr1aeEcaZ8mtu8hNVb4e3rEYvGEwQSr7wsNrW53t6nKYjkmjRICcvVEsXUhjoCblRHSxRsRV0TOt0+UmcvaQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "effect": "^3.21.0",
+        "vitest": "^3.2.0"
+      }
+    },
+    "node_modules/@effect/workflow": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@effect/workflow/-/workflow-0.18.1.tgz",
+      "integrity": "sha512-FxsUxkyvd7CyN7tw4bQgmAJv8tf8hUwy72bwGYzKGpeuiEObiUKgO1pg8xM49gB6EtwOdVRJhytwcFc8eM/6ow==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@effect/experimental": "^0.60.0",
+        "@effect/platform": "^0.96.1",
+        "@effect/rpc": "^0.75.1",
+        "effect": "^3.21.2"
       }
     },
     "node_modules/@emnapi/core": {
@@ -724,6 +939,84 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -743,6 +1036,301 @@
       "integrity": "sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.3",
@@ -836,9 +1424,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -853,9 +1438,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -870,9 +1452,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -887,9 +1466,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -904,9 +1480,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -921,9 +1494,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -938,9 +1508,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -955,9 +1522,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -972,9 +1536,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -989,9 +1550,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1006,9 +1564,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1023,9 +1578,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1040,9 +1592,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1137,7 +1686,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
@@ -1536,9 +2084,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1553,9 +2098,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1570,9 +2112,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1587,9 +2126,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1604,9 +2140,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1621,9 +2154,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1638,9 +2168,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1655,9 +2182,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1724,40 +2248,39 @@
       ]
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
-      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
-        "chai": "^6.2.2",
-        "tinyrainbow": "^3.1.0"
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
-      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.5",
+        "@vitest/spy": "3.2.4",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
+        "magic-string": "^0.30.17"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -1769,42 +2292,42 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
-      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.1.0"
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
-      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.5",
-        "pathe": "^2.0.3"
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
-      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/utils": "4.1.5",
-        "magic-string": "^0.30.21",
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1812,25 +2335,28 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
-      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
-      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -1922,14 +2448,41 @@
         "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/chai": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
-      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/comment-parser": {
@@ -1941,13 +2494,6 @@
       "engines": {
         "node": ">= 12.0.0"
       }
-    },
-    "node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1982,12 +2528,41 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/effect": {
+      "version": "3.21.2",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.2.tgz",
+      "integrity": "sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.21.0",
@@ -2004,9 +2579,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2425,6 +3000,28 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2476,6 +3073,12 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -2603,6 +3206,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/ini": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/is-bun-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
@@ -2617,7 +3229,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2627,7 +3238,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -2652,6 +3262,13 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
@@ -2694,6 +3311,13 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kubernetes-types": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -2724,6 +3348,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2741,6 +3372,18 @@
       "dev": true,
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/minimatch": {
@@ -2764,6 +3407,43 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/msgpackr": {
+      "version": "1.11.12",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.12.tgz",
+      "integrity": "sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
+      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
+      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -2807,6 +3487,27 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
     },
     "node_modules/npm-normalize-package-bin": {
       "version": "4.0.0",
@@ -2870,17 +3571,6 @@
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
-    },
-    "node_modules/obug": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/sxzz",
-        "https://opencollective.com/debug"
-      ],
-      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -2959,6 +3649,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2970,7 +3670,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3056,6 +3755,22 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/read-package-json-fast": {
       "version": "4.0.0",
@@ -3210,11 +3925,24 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
     },
     "node_modules/tapable": {
       "version": "2.3.3",
@@ -3238,14 +3966,11 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
-      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
@@ -3264,15 +3989,41 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
     "node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -3346,6 +4097,15 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -3396,6 +4156,20 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vite": {
@@ -3473,80 +4247,89 @@
         }
       }
     },
-    "node_modules/vitest": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
-      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.5",
-        "@vitest/mocker": "4.1.5",
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/runner": "4.1.5",
-        "@vitest/snapshot": "4.1.5",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
-        "es-module-lexer": "^2.0.0",
-        "expect-type": "^1.3.0",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^4.0.0-rc.1",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
         "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.5",
-        "@vitest/browser-preview": "4.1.5",
-        "@vitest/browser-webdriverio": "4.1.5",
-        "@vitest/coverage-istanbul": "4.1.5",
-        "@vitest/coverage-v8": "4.1.5",
-        "@vitest/ui": "4.1.5",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
         "happy-dom": "*",
-        "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "jsdom": "*"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@opentelemetry/api": {
+        "@types/debug": {
           "optional": true
         },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser-playwright": {
-          "optional": true
-        },
-        "@vitest/browser-preview": {
-          "optional": true
-        },
-        "@vitest/browser-webdriverio": {
-          "optional": true
-        },
-        "@vitest/coverage-istanbul": {
-          "optional": true
-        },
-        "@vitest/coverage-v8": {
+        "@vitest/browser": {
           "optional": true
         },
         "@vitest/ui": {
@@ -3557,9 +4340,6 @@
         },
         "jsdom": {
           "optional": true
-        },
-        "vite": {
-          "optional": false
         }
       }
     },
@@ -3604,6 +4384,42 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yocto-queue": {

--- a/plugins/pr/package.json
+++ b/plugins/pr/package.json
@@ -13,7 +13,15 @@
     "lint:tsc": "tsc --noEmit",
     "test": "vitest run --reporter=verbose"
   },
+  "dependencies": {
+    "@effect/cli": "0.75.1",
+    "@effect/platform": "0.96.1",
+    "@effect/platform-node": "0.106.0",
+    "effect": "3.21.2"
+  },
   "devDependencies": {
+    "@effect/language-service": "0.86.1",
+    "@effect/vitest": "0.29.0",
     "@eslint/compat": "2.1.0",
     "@eslint/js": "10.0.1",
     "@types/node": "22.19.19",
@@ -28,7 +36,7 @@
     "typescript": "6.0.3",
     "typescript-eslint": "8.59.2",
     "vite": "7.3.3",
-    "vitest": "4.1.5"
+    "vitest": "3.2.4"
   },
   "engines": {
     "node": ">=22.19.0"

--- a/plugins/pr/src/bin/konoka-editor.ts
+++ b/plugins/pr/src/bin/konoka-editor.ts
@@ -1,26 +1,34 @@
-import { spawnSync } from "node:child_process";
 import process from "node:process";
+import { Args, Command } from "@effect/cli";
+import { NodeContext, NodeRuntime } from "@effect/platform-node";
+import { Effect } from "effect";
+import { konokaEdit } from "../konoka-editor";
 
-const editorEnv = process.env["EDITOR"];
-const [editor = "emacsclient", ...defaultArgs] = editorEnv
-  ? editorEnv.split(" ")
-  : ["emacsclient", "--reuse-frame", "--alternate-editor=emacs"];
+/**
+ * コマンドライン引数として渡された`PULLREQ_EDITMSG`ファイル。
+ */
+const pullreqEditmsgArg = Args.file({ name: "PULLREQ_EDITMSG", exists: "yes" });
 
-const result = spawnSync(editor, [...defaultArgs, ...process.argv.slice(2)], {
-  stdio: "inherit",
+/**
+ * コマンド処理の本体。
+ */
+const command = Command.make("konoka-editor", { pullreqEditmsgArg }, ({ pullreqEditmsgArg }) =>
+  konokaEdit(pullreqEditmsgArg),
+);
+
+/**
+ * メタデータを含んだコマンド全体。
+ */
+const cli = Command.run(command, {
+  name: "konoka-editor",
+  version: "0.0.0", // あくまで内部プログラムでありバージョンはプラグイン側にあるのでダミー。
 });
 
-function assertEditorSuccess(
-  editorName: string,
-  { error, status }: { error?: Error; status: number | null },
-): void {
-  if (error !== undefined || status !== 0) {
-    const detail = error !== undefined ? `: ${error.message}` : "";
-    throw new Error(
-      `Editor "${editorName}" failed (status ${status})${detail}`,
-      error !== undefined ? { cause: error } : undefined,
-    );
-  }
+/**
+ * エントリーポイントとしてコマンドを起動します。
+ */
+function main(): void {
+  cli(process.argv).pipe(Effect.provide(NodeContext.layer), NodeRuntime.runMain);
 }
 
-assertEditorSuccess(editor, result);
+main();

--- a/plugins/pr/src/bin/prepare-editmsg.ts
+++ b/plugins/pr/src/bin/prepare-editmsg.ts
@@ -1,9 +1,7 @@
-import process from "node:process";
+import { NodeContext, NodeRuntime } from "@effect/platform-node";
+import { Console, Effect } from "effect";
 import { prepareEditmsg } from "../prepare-editmsg";
 
-async function main(): Promise<void> {
-  const path = await prepareEditmsg();
-  process.stdout.write(`${path}\n`);
-}
+const program = prepareEditmsg().pipe(Effect.flatMap((path) => Console.log(path)));
 
-await main();
+NodeRuntime.runMain(program.pipe(Effect.provide(NodeContext.layer)));

--- a/plugins/pr/src/bin/read-contributing.ts
+++ b/plugins/pr/src/bin/read-contributing.ts
@@ -1,11 +1,18 @@
 import process from "node:process";
+import { NodeContext, NodeRuntime } from "@effect/platform-node";
+import { Effect, Option } from "effect";
 import { formatContributing, readContributing } from "../read-contributing";
 
-async function main(): Promise<void> {
-  const file = await readContributing();
-  if (file != null) {
-    process.stdout.write(formatContributing(file));
-  }
-}
+const program = readContributing().pipe(
+  Effect.flatMap((file) =>
+    Option.match(file, {
+      onNone: () => Effect.void,
+      onSome: (f) =>
+        Effect.sync(() => {
+          process.stdout.write(formatContributing(f));
+        }),
+    }),
+  ),
+);
 
-await main();
+NodeRuntime.runMain(program.pipe(Effect.provide(NodeContext.layer)));

--- a/plugins/pr/src/bin/read-pull-request-template.ts
+++ b/plugins/pr/src/bin/read-pull-request-template.ts
@@ -1,14 +1,19 @@
 import process from "node:process";
+import { NodeContext, NodeRuntime } from "@effect/platform-node";
+import { Effect } from "effect";
 import {
   formatPullRequestTemplates,
   readPullRequestTemplates,
 } from "../read-pull-request-template";
 
-async function main(): Promise<void> {
-  const templates = await readPullRequestTemplates();
-  if (0 < templates.length) {
-    process.stdout.write(formatPullRequestTemplates(templates));
-  }
-}
+const program = readPullRequestTemplates().pipe(
+  Effect.flatMap((templates) =>
+    templates.length === 0
+      ? Effect.void
+      : Effect.sync(() => {
+          process.stdout.write(formatPullRequestTemplates(templates));
+        }),
+  ),
+);
 
-await main();
+NodeRuntime.runMain(program.pipe(Effect.provide(NodeContext.layer)));

--- a/plugins/pr/src/bin/sync-and-push.ts
+++ b/plugins/pr/src/bin/sync-and-push.ts
@@ -1,16 +1,20 @@
 import process from "node:process";
-import { displayErrorMessage } from "../run";
+import { NodeContext, NodeRuntime } from "@effect/platform-node";
+import { Console, Effect, Exit } from "effect";
 import { formatSyncAndPush, syncAndPush } from "../sync-and-push";
 
-async function main(): Promise<void> {
-  try {
-    const execResult = await syncAndPush();
-    const output = formatSyncAndPush(execResult);
-    process.stdout.write(output);
-  } catch (err: unknown) {
-    console.error(displayErrorMessage(err));
-    process.exitCode = 1;
-  }
-}
+const program = syncAndPush().pipe(
+  Effect.tap((result) =>
+    Effect.sync(() => {
+      process.stdout.write(formatSyncAndPush(result));
+    }),
+  ),
+  // 全ての型付きエラーは`.message`に必要な情報を畳み込んでいるので、
+  // ここでstderrに出して、後段の`disableErrorReporting`でEffectの冗長ログを抑制します。
+  Effect.tapError((err) => Console.error(err.message)),
+);
 
-await main();
+NodeRuntime.runMain(program.pipe(Effect.provide(NodeContext.layer)), {
+  disableErrorReporting: true,
+  teardown: (exit, onExit) => onExit(Exit.isSuccess(exit) ? 0 : 1),
+});

--- a/plugins/pr/src/konoka-editor.ts
+++ b/plugins/pr/src/konoka-editor.ts
@@ -1,0 +1,79 @@
+import { Command } from "@effect/platform";
+import type { CommandExecutor } from "@effect/platform/CommandExecutor";
+import type { PlatformError } from "@effect/platform/Error";
+import { Config, Data, Effect } from "effect";
+
+export class EditorFailedError extends Data.TaggedError("EditorFailedError")<{
+  readonly editor: string;
+  readonly exitCode: number;
+}> {
+  override get message(): string {
+    return `Editor command "${this.editor}" failed with exit code ${this.exitCode}.`;
+  }
+}
+
+/**
+ * 環境変数`EDITOR`が未設定または空のときに使うデフォルトのエディタコマンドです。
+ */
+export const defaultEditor = "emacsclient --reuse-frame --alternate-editor=emacs" as const;
+
+/**
+ * 環境変数`EDITOR`の値を取得し、
+ * 未設定または空文字列の場合は`defaultEditor`を返します。
+ *
+ * `EDITOR`はユーザが設定するものなので信頼できる文字列として扱います。
+ * シェルが解釈するコマンド文字列としてそのまま`sh -c`に渡される前提です。
+ */
+export const editorCommand: Effect.Effect<string> = Config.nonEmptyString("EDITOR").pipe(
+  Effect.orElseSucceed(() => defaultEditor),
+);
+
+/**
+ * `EDITOR`コマンド文字列とファイルパスから、
+ * `sh -c`経由で起動するための`argv`を生成します。
+ *
+ * gitやsudoeditと同じく、
+ * `EDITOR`はシェルが解釈するコマンド文字列として扱います。
+ * 実行ファイルパスにスペースがある場合はユーザがクオートで対処します。
+ * ファイルパスは`"$@"`経由の位置引数として渡し、
+ * シェル側での再解釈を避けます。
+ */
+export function buildEditorInvocation(
+  editor: string,
+  file: string,
+): readonly ["sh", "-c", string, "konoka-editor", string] {
+  return [
+    "sh",
+    "-c",
+    `${editor} "$@"`,
+    // `sh -c <script> <argv0> <argv1>...`の引数列で、
+    // `<argv0>`はスクリプト内の`$0`に入ります。
+    // シェルがエラーメッセージを出す際の名乗りに使われるので、ここを`konoka-editor`にしておくと、
+    // `konoka-editor: <editor>: not found`のように出所の追跡しやすい表示になります。
+    "konoka-editor",
+    file,
+  ];
+}
+
+/**
+ * コマンドを推定して起動して編集を行います。
+ */
+export function konokaEdit(
+  editmsgArg: string,
+): Effect.Effect<void, PlatformError, CommandExecutor> {
+  return Effect.gen(function* () {
+    const editor = yield* editorCommand;
+    const [executable, ...args] = buildEditorInvocation(editor, editmsgArg);
+    const cmd = Command.make(executable, ...args).pipe(
+      Command.stdin("inherit"),
+      Command.stdout("inherit"),
+      Command.stderr("inherit"),
+    );
+    yield* Command.exitCode(cmd).pipe(
+      Effect.filterOrDie(
+        (code) => code === 0,
+        (code) => new EditorFailedError({ editor, exitCode: code }),
+      ),
+    );
+  });
+}

--- a/plugins/pr/src/prepare-editmsg.ts
+++ b/plugins/pr/src/prepare-editmsg.ts
@@ -1,47 +1,50 @@
-import { mkdir, mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import process from "node:process";
-
-export interface PrepareEditmsgOptions {
-  readonly runtimeDir?: string;
-}
-
-/** なるべくユーザの固有の作業ディレクトリを返します */
-function getPersonalWorkDir(): string {
-  const runtimeDir = process.env["XDG_RUNTIME_DIR"];
-  if (runtimeDir != null && runtimeDir !== "") {
-    return runtimeDir;
-  }
-  return tmpdir();
-}
-
-/** LLMエージェントなどが一時ファイルを置いて良さそうなディレクトリを返します。 */
-function getCodingAgentWorkDir(pluginName: string): string {
-  const personalWorkDir = getPersonalWorkDir();
-  return join(personalWorkDir, "coding-agent-work", pluginName);
-}
+import { FileSystem, Path } from "@effect/platform";
+import type { PlatformError } from "@effect/platform/Error";
+import { Config, Effect } from "effect";
 
 const pluginName = "pr" as const;
 const fileName = "PULLREQ_EDITMSG" as const;
+
+export interface PrepareEditmsgOptions {
+  /**
+   * テスト用の基底ディレクトリ上書きオプション。
+   * 通常用途では指定しません。
+   * 指定された場合は`coding-agent-work/`サブパスを付けずに基底ディレクトリとして使います。
+   */
+  readonly runtimeDir?: string;
+}
+
+const personalWorkDir: Effect.Effect<string> = Config.nonEmptyString("XDG_RUNTIME_DIR").pipe(
+  Effect.orElseSucceed(() => tmpdir()),
+);
+
+const codingAgentWorkDir: Effect.Effect<string, never, Path.Path> = Effect.gen(function* () {
+  const path = yield* Path.Path;
+  const base = yield* personalWorkDir;
+  return path.join(base, "coding-agent-work", pluginName);
+});
 
 /**
  * セッション固有の一時ディレクトリを作成し、`PULLREQ_EDITMSG`ファイルのフルパスを返します。
  *
  * 作業ディレクトリの基底は`$XDG_RUNTIME_DIR/coding-agent-work/pr/`を使い、
  * 未設定環境では`os.tmpdir()`にフォールバックします。
- * 親ディレクトリが無い場合は`mkdir -p`相当で再帰的に作成し、
- * その下に`mkdtemp`でセッション固有のサブディレクトリを掘ります。
+ * 親ディレクトリが無い場合は再帰的に作成し、
+ * その下に`makeTempDirectory`でセッション固有のサブディレクトリを掘ります。
  * `PULLREQ_EDITMSG`本体は呼び出し側でこのパスに書き出してください。
- *
- * `options.runtimeDir`はテスト用のオプションであって、
- * 通常使うことを想定していません。
- * これが指定された時は`coding-agent-work/`サブパスを付けずに基底ディレクトリとして使います。
  */
-export async function prepareEditmsg(options: PrepareEditmsgOptions = {}): Promise<string> {
-  const runtimeDir = options.runtimeDir !== "" ? options.runtimeDir : undefined;
-  const codingAgentWorkDir = runtimeDir ?? getCodingAgentWorkDir(pluginName);
-  await mkdir(codingAgentWorkDir, { recursive: true, mode: 0o700 });
-  const sessionDir = await mkdtemp(join(codingAgentWorkDir, "session-"));
-  return join(sessionDir, fileName);
+export function prepareEditmsg(
+  options: PrepareEditmsgOptions = {},
+): Effect.Effect<string, PlatformError, FileSystem.FileSystem | Path.Path> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const override =
+      options.runtimeDir != null && options.runtimeDir !== "" ? options.runtimeDir : undefined;
+    const baseDir = override ?? (yield* codingAgentWorkDir);
+    yield* fs.makeDirectory(baseDir, { recursive: true, mode: 0o700 });
+    const sessionDir = yield* fs.makeTempDirectory({ directory: baseDir, prefix: "session-" });
+    return path.join(sessionDir, fileName);
+  });
 }

--- a/plugins/pr/src/push-head.ts
+++ b/plugins/pr/src/push-head.ts
@@ -1,6 +1,9 @@
-import { CommandError, run, tryRun } from "./run";
+import type { CommandExecutor } from "@effect/platform/CommandExecutor";
+import type { PlatformError } from "@effect/platform/Error";
+import { Data, Effect, Option, ParseResult, Schema } from "effect";
+import { CommandFailedError, runStdout, tryRunStdout } from "./run";
 
-/** push-head.tsが取り得る動作の種類。 */
+/** `pushHead`が取り得る動作の種類。 */
 export type PushAction = "none" | "initial" | "normal" | "force";
 
 export interface PushHeadResult {
@@ -13,62 +16,107 @@ interface AheadBehind {
   readonly ahead: number;
 }
 
-export function parseAheadBehind(out: string): AheadBehind {
+/** `git rev-list --left-right --count`の出力パース失敗を表すロジックエラー。 */
+export class RevListParseError extends Data.TaggedError("RevListParseError")<{
+  readonly message: string;
+}> {}
+
+/** ローカルがupstreamより遅れている異常状態を表します。 */
+export class BehindUpstreamError extends Data.TaggedError("BehindUpstreamError")<{
+  readonly behind: number;
+}> {
+  override get message(): string {
+    return (
+      `Local branch is behind upstream by ${String(this.behind)} commit(s).` +
+      ` Pull or rebase before retry.`
+    );
+  }
+}
+
+/** 同名ブランチに既に開いているPRがあったためforce pushを拒否したことを表します。 */
+export class ExistingOpenPullRequestError extends Data.TaggedError("ExistingOpenPullRequestError")<{
+  readonly branch: string;
+  readonly number: number;
+}> {
+  override get message(): string {
+    return [
+      `An open pull request #${String(this.number)}`,
+      `already exists for branch ${this.branch}.`,
+      "Cancel this skill and update the existing PR instead of force-pushing.",
+    ].join(" ");
+  }
+}
+
+export function parseAheadBehind(out: string): Effect.Effect<AheadBehind, RevListParseError> {
   function isNonNegativeInteger(x: unknown): boolean {
     return typeof x === "number" && Number.isInteger(x) && 0 <= x;
   }
 
   const parts = out.split(/\s+/);
   if (parts.length < 2) {
-    throw new CommandError(`Failed to parse rev-list output: ${out}`, "");
+    return Effect.fail(
+      new RevListParseError({ message: `Failed to parse rev-list output: ${out}` }),
+    );
   }
   const behind = Number(parts[0]);
   const ahead = Number(parts[1]);
   if (!isNonNegativeInteger(behind) || !isNonNegativeInteger(ahead)) {
-    throw new CommandError(`Failed to parse rev-list output: ${out}`, "");
+    return Effect.fail(
+      new RevListParseError({ message: `Failed to parse rev-list output: ${out}` }),
+    );
   }
-  return { behind, ahead };
+  return Effect.succeed({ behind, ahead });
 }
 
-interface OpenPr {
-  readonly number: number;
-}
+/** `gh pr list --json number`の出力スキーマ。 */
+const OpenPrSchema = Schema.Struct({ number: Schema.Number });
 
-export function parseOpenPr(json: string): OpenPr | undefined {
-  const value: unknown = JSON.parse(json);
-  if (!Array.isArray(value) || value.length === 0) {
-    return undefined;
-  }
-  const first: unknown = value[0];
-  if (
-    typeof first === "object" &&
-    first !== null &&
-    "number" in first &&
-    typeof first.number === "number"
-  ) {
-    return { number: first.number };
-  }
-  throw new CommandError(`Failed to parse gh pr list output: ${json}`, "");
+/** 上記の配列形式から先頭1件を取り出すスキーマ。JSON文字列を直接デコードします。 */
+const OpenPrListFromJson = Schema.parseJson(Schema.Array(OpenPrSchema));
+
+type OpenPr = Schema.Schema.Type<typeof OpenPrSchema>;
+
+/**
+ * `gh pr list --json number`が返したJSONをデコードし、
+ * 先頭の1件を`Option`で返します。
+ *
+ * 検証とデコードを`Schema.parseJson` + `Schema.decodeUnknown`に委ねるため、
+ * 失敗時のエラー型は`ParseResult.ParseError`になります。
+ */
+export function parseOpenPr(
+  json: string,
+): Effect.Effect<Option.Option<OpenPr>, ParseResult.ParseError> {
+  return Schema.decodeUnknown(OpenPrListFromJson)(json).pipe(
+    Effect.map((entries) => Option.fromNullable(entries[0])),
+  );
 }
 
 /**
  * カレントブランチ名で開いているPRを返します。
- * ない場合は`undefined`。
+ * ない場合は`Option.none`。
  * fork経由で同名ブランチからPRが作成されているケースは検知できません。
  */
-async function findOpenPullRequest(branch: string): Promise<OpenPr | undefined> {
-  const json = await run("gh", [
-    "pr",
-    "list",
-    `--head=${branch}`,
-    "--state",
-    "open",
-    "--json",
-    "number",
-    "--limit",
-    "1",
-  ]);
-  return parseOpenPr(json);
+function findOpenPullRequest(
+  branch: string,
+): Effect.Effect<
+  Option.Option<OpenPr>,
+  CommandFailedError | PlatformError | ParseResult.ParseError,
+  CommandExecutor
+> {
+  return Effect.gen(function* () {
+    const json = yield* runStdout("gh", [
+      "pr",
+      "list",
+      `--head=${branch}`,
+      "--state",
+      "open",
+      "--json",
+      "number",
+      "--limit",
+      "1",
+    ]);
+    return yield* parseOpenPr(json);
+  });
 }
 
 /**
@@ -78,72 +126,80 @@ async function findOpenPullRequest(branch: string): Promise<OpenPr | undefined> 
  * - 完全一致: `none`(pushは不要)
  * - ローカルのみ先行: `normal`(通常push)
  * - 履歴が分岐(ahead && behind): `force`(force-with-leaseが必要)
- * - リモートのみ先行: 異常状態としてエラーを投げる
+ * - リモートのみ先行: 異常状態として`BehindUpstreamError`で失敗
  */
-async function detectAction(): Promise<PushAction> {
-  const upstream = await tryRun("git", [
-    "rev-parse",
-    "--abbrev-ref",
-    "--symbolic-full-name",
-    "@{u}",
-  ]);
-  if (upstream === undefined) {
-    return "initial";
-  }
-  const aheadBehind = parseAheadBehind(
-    await run("git", ["rev-list", "--left-right", "--count", "@{u}...HEAD"]),
-  );
-  if (aheadBehind.behind === 0 && aheadBehind.ahead === 0) {
-    return "none";
-  }
-  if (aheadBehind.behind === 0 && aheadBehind.ahead > 0) {
-    return "normal";
-  }
-  if (aheadBehind.behind > 0 && aheadBehind.ahead === 0) {
-    throw new CommandError(
-      `Local branch is behind upstream by ${String(aheadBehind.behind)} commit(s).` +
-        " Pull or rebase before retry.",
-      "",
+function detectAction(): Effect.Effect<
+  PushAction,
+  CommandFailedError | PlatformError | RevListParseError | BehindUpstreamError,
+  CommandExecutor
+> {
+  return Effect.gen(function* () {
+    const upstream = yield* tryRunStdout("git", [
+      "rev-parse",
+      "--abbrev-ref",
+      "--symbolic-full-name",
+      "@{u}",
+    ]);
+    if (Option.isNone(upstream)) {
+      return "initial" as const;
+    }
+    const aheadBehind = yield* parseAheadBehind(
+      yield* runStdout("git", ["rev-list", "--left-right", "--count", "@{u}...HEAD"]),
     );
-  }
-  return "force";
+    if (aheadBehind.behind === 0 && aheadBehind.ahead === 0) {
+      return "none" as const;
+    }
+    if (aheadBehind.behind === 0 && aheadBehind.ahead > 0) {
+      return "normal" as const;
+    }
+    if (aheadBehind.behind > 0 && aheadBehind.ahead === 0) {
+      return yield* new BehindUpstreamError({ behind: aheadBehind.behind });
+    }
+    return "force" as const;
+  });
 }
 
 /**
  * カレントブランチをremoteに同期するためのpushを実行します。
  *
  * `force`が必要な場合は事前に同名ブランチをheadとするopen PRが存在しないことを確認し、
- * 既に存在する場合はforce pushを行わずにエラーを投げてスキルの中断を促します。
+ * 既に存在する場合はforce pushを行わずに`ExistingOpenPullRequestError`で失敗してスキルの中断を促します。
  */
-export async function pushHead(): Promise<PushHeadResult> {
-  const remote = "origin";
-  const currentBranch = await run("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
+export function pushHead(): Effect.Effect<
+  PushHeadResult,
+  | CommandFailedError
+  | PlatformError
+  | RevListParseError
+  | ParseResult.ParseError
+  | BehindUpstreamError
+  | ExistingOpenPullRequestError,
+  CommandExecutor
+> {
+  return Effect.gen(function* () {
+    const remote = "origin";
+    const currentBranch = yield* runStdout("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
+    const action = yield* detectAction();
 
-  const action = await detectAction();
-
-  switch (action) {
-    case "none":
-      return { currentBranch, action };
-    case "initial":
-      await run("git", ["push", "-u", "--", remote, currentBranch]);
-      return { currentBranch, action };
-    case "normal":
-      await run("git", ["push", "--", remote, currentBranch]);
-      return { currentBranch, action };
-    case "force": {
-      const openPr = await findOpenPullRequest(currentBranch);
-      if (openPr !== undefined) {
-        throw new CommandError(
-          [
-            `An open pull request #${String(openPr.number)}`,
-            `already exists for branch ${currentBranch}.`,
-            "Cancel this skill and update the existing PR instead of force-pushing.",
-          ].join(" "),
-          "",
-        );
+    switch (action) {
+      case "none":
+        return { currentBranch, action };
+      case "initial":
+        yield* runStdout("git", ["push", "-u", "--", remote, currentBranch]);
+        return { currentBranch, action };
+      case "normal":
+        yield* runStdout("git", ["push", "--", remote, currentBranch]);
+        return { currentBranch, action };
+      case "force": {
+        const openPr = yield* findOpenPullRequest(currentBranch);
+        if (Option.isSome(openPr)) {
+          return yield* new ExistingOpenPullRequestError({
+            branch: currentBranch,
+            number: openPr.value.number,
+          });
+        }
+        yield* runStdout("git", ["push", "--force-with-lease", "--", remote, currentBranch]);
+        return { currentBranch, action };
       }
-      await run("git", ["push", "--force-with-lease", "--", remote, currentBranch]);
-      return { currentBranch, action };
     }
-  }
+  });
 }

--- a/plugins/pr/src/read-contributing.ts
+++ b/plugins/pr/src/read-contributing.ts
@@ -1,15 +1,16 @@
-import { join } from "node:path";
+import { FileSystem, Path } from "@effect/platform";
+import type { PlatformError } from "@effect/platform/Error";
+import { Effect, Option } from "effect";
 import { findCaseInsensitive, readIfExists } from "./read-if-exists";
 
 /**
- * Search locations for the contributing guideline file.
- *
- * Ordered by GitHub's display priority. The first match wins.
+ * `CONTRIBUTING`ガイドラインの検索場所。
+ * GitHubの表示優先度の順に並べ、最初に見つかったものを採用します。
  */
 const CONTRIBUTING_LOCATIONS = [".github", ".", "docs"] as const;
 
 /**
- * Canonical file name. Case-insensitive variants are absorbed at runtime.
+ * 正規のファイル名。大文字小文字のバリエーションは実行時に吸収します。
  */
 const CONTRIBUTING_NAME = "CONTRIBUTING.md" as const;
 
@@ -18,37 +19,50 @@ export interface ContributingFile {
   readonly content: string;
 }
 
-async function readAtLocation(
+function readAtLocation(
   root: string,
   location: string,
-): Promise<ContributingFile | undefined> {
-  const dir = join(root, location);
-  const found = await findCaseInsensitive(dir, CONTRIBUTING_NAME);
-  if (found == null) {
-    return undefined;
-  }
-  const path = location === "." ? found : join(location, found);
-  const content = await readIfExists(join(root, path));
-  if (content == null) {
-    return undefined;
-  }
-  return { path, content };
+): Effect.Effect<
+  Option.Option<ContributingFile>,
+  PlatformError,
+  FileSystem.FileSystem | Path.Path
+> {
+  return Effect.gen(function* () {
+    const path = yield* Path.Path;
+    const dir = path.join(root, location);
+    const found = yield* findCaseInsensitive(dir, CONTRIBUTING_NAME);
+    if (Option.isNone(found)) {
+      return Option.none<ContributingFile>();
+    }
+    const relativePath = location === "." ? found.value : path.join(location, found.value);
+    const content = yield* readIfExists(path.join(root, relativePath));
+    return Option.map(content, (c) => ({ path: relativePath, content: c }));
+  });
 }
 
 /**
- * Read the repository's contributing guideline file if it exists.
+ * リポジトリの`CONTRIBUTING`ガイドラインがあれば読み込みます。
  *
- * @param root Repository root to search from. Defaults to the current working directory.
+ * @param root 検索ルート。省略時はカレントディレクトリ。
  */
-export async function readContributing(root = "."): Promise<ContributingFile | undefined> {
-  const candidates = await Promise.all(
-    CONTRIBUTING_LOCATIONS.map((location) => readAtLocation(root, location)),
-  );
-  return candidates.find((candidate) => candidate != null);
+export function readContributing(
+  root = ".",
+): Effect.Effect<
+  Option.Option<ContributingFile>,
+  PlatformError,
+  FileSystem.FileSystem | Path.Path
+> {
+  return Effect.gen(function* () {
+    const candidates = yield* Effect.all(
+      CONTRIBUTING_LOCATIONS.map((location) => readAtLocation(root, location)),
+      { concurrency: "unbounded" },
+    );
+    return Option.fromNullable(candidates.find(Option.isSome)).pipe(Option.flatten);
+  });
 }
 
 /**
- * Format a contributing file as a markdown section.
+ * `CONTRIBUTING`ファイルをmarkdownのセクションとして整形します。
  */
 export function formatContributing(file: ContributingFile): string {
   return `# ${file.path}\n\n${file.content}`;

--- a/plugins/pr/src/read-if-exists.ts
+++ b/plugins/pr/src/read-if-exists.ts
@@ -1,46 +1,60 @@
-import { readFile, readdir } from "node:fs/promises";
+import { FileSystem } from "@effect/platform";
+import type { PlatformError } from "@effect/platform/Error";
+import { Effect, Option } from "effect";
 
 /**
- * Read a file as UTF-8, returning undefined if the file does not exist.
+ * UTF-8としてファイルを読み、存在しない場合は`Option.none`を返します。
  */
-export async function readIfExists(path: string): Promise<string | undefined> {
-  try {
-    return await readFile(path, "utf8");
-  } catch (err: unknown) {
-    if (err instanceof Error && "code" in err && err.code === "ENOENT") {
-      // if file don't exist, ignore error.
-      return undefined;
-    }
-    throw new Error(`Failed to read file: ${path}`, { cause: err });
-  }
+export function readIfExists(
+  path: string,
+): Effect.Effect<Option.Option<string>, PlatformError, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    return yield* fs.readFileString(path, "utf8").pipe(
+      Effect.map(Option.some),
+      Effect.catchTag("SystemError", (err) =>
+        err.reason === "NotFound" ? Effect.succeed(Option.none<string>()) : Effect.fail(err),
+      ),
+    );
+  });
 }
 
 /**
- * List directory entries, returning undefined if the directory does not exist.
+ * ディレクトリの内容を読み、存在しない場合は`Option.none`を返します。
  */
-export async function readdirIfExists(path: string): Promise<readonly string[] | undefined> {
-  try {
-    return await readdir(path);
-  } catch (err: unknown) {
-    if (err instanceof Error && "code" in err && err.code === "ENOENT") {
-      // if dir don't exist, ignore error.
-      return undefined;
-    }
-    throw new Error(`Failed to read directory: ${path}`, { cause: err });
-  }
+export function readdirIfExists(
+  path: string,
+): Effect.Effect<Option.Option<readonly string[]>, PlatformError, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    return yield* fs.readDirectory(path).pipe(
+      Effect.map((entries): Option.Option<readonly string[]> => Option.some(entries)),
+      Effect.catchTag("SystemError", (err) =>
+        err.reason === "NotFound"
+          ? Effect.succeed(Option.none<readonly string[]>())
+          : Effect.fail(err),
+      ),
+    );
+  });
 }
 
 /**
- * Find an entry in a directory by case-insensitive name match.
+ * ディレクトリエントリを大文字小文字を区別せずに検索します。
  *
- * GitHubはCONTRIBUTING.mdやpull_request_template.mdなどの特殊ファイルを大文字小文字を区別せずに認識します。
+ * GitHubは`CONTRIBUTING.md`や`pull_request_template.md`などの特殊ファイルを大文字小文字を区別せずに認識します。
  * コード上の候補を正規の表記1つに絞り、実行時にファイルシステム側のバリエーションを吸収します。
  */
-export async function findCaseInsensitive(dir: string, name: string): Promise<string | undefined> {
-  const entries = await readdirIfExists(dir);
-  if (entries == null) {
-    return undefined;
-  }
-  const lower = name.toLowerCase();
-  return entries.toSorted().find((entry) => entry.toLowerCase() === lower);
+export function findCaseInsensitive(
+  dir: string,
+  name: string,
+): Effect.Effect<Option.Option<string>, PlatformError, FileSystem.FileSystem> {
+  return readdirIfExists(dir).pipe(
+    Effect.map((entries) =>
+      Option.flatMap(entries, (list) => {
+        const lower = name.toLowerCase();
+        const found = list.toSorted().find((entry) => entry.toLowerCase() === lower);
+        return Option.fromNullable(found);
+      }),
+    ),
+  );
 }

--- a/plugins/pr/src/read-pull-request-template.ts
+++ b/plugins/pr/src/read-pull-request-template.ts
@@ -1,20 +1,21 @@
-import { join } from "node:path";
+import { FileSystem, Path } from "@effect/platform";
+import type { PlatformError } from "@effect/platform/Error";
+import { Effect, Option } from "effect";
 import { findCaseInsensitive, readIfExists, readdirIfExists } from "./read-if-exists";
 
 /**
- * Search locations for pull request templates.
- *
- * Ordered by GitHub's display priority. All matches are returned.
+ * pull requestテンプレートの検索場所。
+ * GitHubの表示優先度の順に並べ、全マッチを返します。
  */
 const TEMPLATE_LOCATIONS = [".github", "docs", "."] as const;
 
 /**
- * Canonical single-file template name. Case-insensitive variants are absorbed at runtime.
+ * 単一ファイル形式の正規ファイル名。大文字小文字のバリエーションは実行時に吸収します。
  */
 const TEMPLATE_FILE_NAME = "pull_request_template.md" as const;
 
 /**
- * Canonical multi-template directory name. Case-insensitive variants are absorbed at runtime.
+ * 複数テンプレート形式の正規ディレクトリ名。大文字小文字のバリエーションは実行時に吸収します。
  */
 const TEMPLATE_DIR_NAME = "PULL_REQUEST_TEMPLATE" as const;
 
@@ -23,79 +24,93 @@ export interface PullRequestTemplate {
   readonly content: string;
 }
 
-function locationPath(location: string, name: string): string {
-  return location === "." ? name : join(location, name);
-}
-
-async function readSingleAtLocation(
+function readSingleAtLocation(
   root: string,
   location: string,
-): Promise<PullRequestTemplate | undefined> {
-  const dir = join(root, location);
-  const found = await findCaseInsensitive(dir, TEMPLATE_FILE_NAME);
-  if (found == null) {
-    return undefined;
-  }
-  const path = locationPath(location, found);
-  const content = await readIfExists(join(root, path));
-  if (content == null) {
-    return undefined;
-  }
-  return { path, content };
+): Effect.Effect<
+  Option.Option<PullRequestTemplate>,
+  PlatformError,
+  FileSystem.FileSystem | Path.Path
+> {
+  return Effect.gen(function* () {
+    const path = yield* Path.Path;
+    const dir = path.join(root, location);
+    const found = yield* findCaseInsensitive(dir, TEMPLATE_FILE_NAME);
+    if (Option.isNone(found)) {
+      return Option.none<PullRequestTemplate>();
+    }
+    const relativePath = location === "." ? found.value : path.join(location, found.value);
+    const content = yield* readIfExists(path.join(root, relativePath));
+    return Option.map(content, (c) => ({ path: relativePath, content: c }));
+  });
 }
 
-async function readMultiAtLocation(
+function readMultiAtLocation(
   root: string,
   location: string,
-): Promise<readonly PullRequestTemplate[]> {
-  const dir = join(root, location);
-  const found = await findCaseInsensitive(dir, TEMPLATE_DIR_NAME);
-  if (found == null) {
-    return [];
-  }
-  const templateDir = locationPath(location, found);
-  const entries = await readdirIfExists(join(root, templateDir));
-  if (entries == null) {
-    return [];
-  }
-  const candidates = (
-    await Promise.all(
-      entries
-        .filter((entry) => entry.toLowerCase().endsWith(".md"))
-        .map(async (entry) => {
-          const path = join(templateDir, entry);
-          const content = await readIfExists(join(root, path));
-          if (content == null) {
-            return undefined;
-          }
-          return { path, content };
+): Effect.Effect<readonly PullRequestTemplate[], PlatformError, FileSystem.FileSystem | Path.Path> {
+  return Effect.gen(function* () {
+    const path = yield* Path.Path;
+    const dir = path.join(root, location);
+    const found = yield* findCaseInsensitive(dir, TEMPLATE_DIR_NAME);
+    if (Option.isNone(found)) {
+      return [] as readonly PullRequestTemplate[];
+    }
+    const templateDir = location === "." ? found.value : path.join(location, found.value);
+    const entries = yield* readdirIfExists(path.join(root, templateDir));
+    if (Option.isNone(entries)) {
+      return [] as readonly PullRequestTemplate[];
+    }
+    const mdEntries = entries.value.filter((entry) => entry.toLowerCase().endsWith(".md"));
+    const templates = yield* Effect.all(
+      mdEntries.map((entry) =>
+        Effect.gen(function* () {
+          const relativePath = path.join(templateDir, entry);
+          const content = yield* readIfExists(path.join(root, relativePath));
+          return Option.map(
+            content,
+            (c): PullRequestTemplate => ({ path: relativePath, content: c }),
+          );
         }),
-    )
-  ).filter((template) => template != null);
-  return candidates;
+      ),
+      { concurrency: "unbounded" },
+    );
+    return templates.filter(Option.isSome).map((opt) => opt.value);
+  });
 }
 
 /**
- * Read all pull request templates available in the repository.
+ * リポジトリに存在する全てのpull requestテンプレートを読み込みます。
  *
- * Both single-file templates and multi-template directories are inspected.
+ * 単一ファイル形式と複数ファイル形式の両方を走査します。
  *
- * @param root Repository root to search from. Defaults to the current working directory.
+ * @param root 検索ルート。省略時はカレントディレクトリ。
  */
-export async function readPullRequestTemplates(
+export function readPullRequestTemplates(
   root = ".",
-): Promise<readonly PullRequestTemplate[]> {
-  const [singleResults, multiResults] = await Promise.all([
-    Promise.all(TEMPLATE_LOCATIONS.map((location) => readSingleAtLocation(root, location))),
-    Promise.all(TEMPLATE_LOCATIONS.map((location) => readMultiAtLocation(root, location))),
-  ]);
-  return [...singleResults.filter((template) => template != null), ...multiResults.flat()];
+): Effect.Effect<readonly PullRequestTemplate[], PlatformError, FileSystem.FileSystem | Path.Path> {
+  return Effect.gen(function* () {
+    const [singleResults, multiResults] = yield* Effect.all(
+      [
+        Effect.all(
+          TEMPLATE_LOCATIONS.map((location) => readSingleAtLocation(root, location)),
+          { concurrency: "unbounded" },
+        ),
+        Effect.all(
+          TEMPLATE_LOCATIONS.map((location) => readMultiAtLocation(root, location)),
+          { concurrency: "unbounded" },
+        ),
+      ],
+      { concurrency: "unbounded" },
+    );
+    return [...singleResults.filter(Option.isSome).map((opt) => opt.value), ...multiResults.flat()];
+  });
 }
 
 /**
- * Format pull request templates as a single markdown document.
+ * pull requestテンプレート群を1つのmarkdown文書として整形します。
  *
- * Each template is rendered as a section separated by horizontal rules.
+ * 各テンプレートを区切り線で連結したセクションとしてレンダリングします。
  */
 export function formatPullRequestTemplates(templates: readonly PullRequestTemplate[]): string {
   return templates.map(({ path, content }) => `# ${path}\n\n${content}`).join("\n\n---\n\n");

--- a/plugins/pr/src/run.ts
+++ b/plugins/pr/src/run.ts
@@ -64,7 +64,7 @@ export function runStdout(
           stderr,
         });
       }
-      return stdout;
+      return stdout.trim();
     }),
   );
 }

--- a/plugins/pr/src/run.ts
+++ b/plugins/pr/src/run.ts
@@ -1,7 +1,7 @@
 import { Command } from "@effect/platform";
 import type { CommandExecutor } from "@effect/platform/CommandExecutor";
 import type { PlatformError } from "@effect/platform/Error";
-import { Data, Effect, Option, Stream } from "effect";
+import { String, Data, Effect, Option, pipe, Stream } from "effect";
 
 /**
  * 子プロセスが非0で終了した場合に投げる構造化エラーです。
@@ -21,12 +21,11 @@ export class CommandFailedError extends Data.TaggedError("CommandFailedError")<{
   }
 }
 
-function concatBytes(acc: Uint8Array, curr: Uint8Array): Uint8Array {
-  const out = new Uint8Array(acc.length + curr.length);
-  out.set(acc);
-  out.set(curr, acc.length);
-  return out;
-}
+/**
+ * `Stream`を`string`にお手軽に変換します。
+ */
+const runString = <E, R>(stream: Stream.Stream<Uint8Array, E, R>): Effect.Effect<string, E, R> =>
+  stream.pipe(Stream.decodeText(), Stream.runFold(String.empty, String.concat));
 
 /**
  * 子プロセスを実行し、標準出力をtrim済みの文字列で返します。
@@ -38,25 +37,34 @@ export function runStdout(
 ): Effect.Effect<string, CommandFailedError | PlatformError, CommandExecutor> {
   return Effect.scoped(
     Effect.gen(function* () {
-      const process = yield* Command.start(Command.make(cmd, ...args));
-      const decoder = new TextDecoder();
-      const [stdoutBytes, stderrBytes, exitCode] = yield* Effect.all(
-        [
-          Stream.runFold(process.stdout, new Uint8Array(), concatBytes),
-          Stream.runFold(process.stderr, new Uint8Array(), concatBytes),
-          process.exitCode,
-        ],
-        { concurrency: "unbounded" },
+      const command = Command.make(cmd, ...args);
+      const [exitCode, stdout, stderr] = yield* pipe(
+        // Start running the command and return a handle to the running process
+        Command.start(command),
+        Effect.flatMap((process) =>
+          Effect.all(
+            [
+              // Waits for the process to exit and returns
+              // the ExitCode of the command that was run
+              process.exitCode,
+              // The standard output stream of the process
+              runString(process.stdout),
+              // The standard error stream of the process
+              runString(process.stderr),
+            ],
+            { concurrency: 3 },
+          ),
+        ),
       );
       if (exitCode !== 0) {
         return yield* new CommandFailedError({
           command: cmd,
           args,
           exitCode,
-          stderr: decoder.decode(stderrBytes).trim(),
+          stderr,
         });
       }
-      return decoder.decode(stdoutBytes).trim();
+      return stdout;
     }),
   );
 }

--- a/plugins/pr/src/run.ts
+++ b/plugins/pr/src/run.ts
@@ -70,7 +70,9 @@ export function runStdout(
 }
 
 /**
- * `runStdout`の失敗を握り潰す版です。
+ * `runStdout`のバリアントです。
+ * 非0終了による失敗のみを`Option.none`に畳み、
+ * プロセス起動自体の失敗は依然として伝播します。
  * upstream未設定時の`git rev-parse @{u}`のように、
  * 失敗自体が情報として意味を持つ呼び出しで使います。
  */

--- a/plugins/pr/src/run.ts
+++ b/plugins/pr/src/run.ts
@@ -1,77 +1,77 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-
-const exec = promisify(execFile);
+import { Command } from "@effect/platform";
+import type { CommandExecutor } from "@effect/platform/CommandExecutor";
+import type { PlatformError } from "@effect/platform/Error";
+import { Data, Effect, Option, Stream } from "effect";
 
 /**
- * 子プロセス実行絡みのエラーを表す共通の例外型。
+ * 子プロセスが非0で終了した場合に投げる構造化エラーです。
  * `stderr`は子プロセスからの標準エラー出力をそのまま保持しますが、
- * ロジック由来で投げる場合は空文字列で構いません。
+ * 取得できなかった場合は空文字列で構いません。
  */
-export class CommandError extends Error {
-  public readonly stderr: string;
-
-  public constructor(message: string, stderr: string, options?: ErrorOptions) {
-    super(message, options);
-    this.name = "CommandError";
-    this.stderr = stderr;
+export class CommandFailedError extends Data.TaggedError("CommandFailedError")<{
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly exitCode: number;
+  readonly stderr: string;
+}> {
+  override get message(): string {
+    const cmdline = [this.command, ...this.args].join(" ");
+    const head = `Command failed: ${cmdline} (exit ${this.exitCode})`;
+    return this.stderr === "" ? head : `${head}\n${this.stderr}`;
   }
 }
 
-/**
- * `CommandError`を投げるべき状況ならそれを投げ、
- * そうでないなら普通に例外を再スローします。
- */
-export function throwCommandError(msg: string, err: unknown): never {
-  if (err instanceof CommandError) {
-    throw new CommandError(msg, err.stderr, { cause: err });
-  }
-  if (err instanceof Error && "stderr" in err && typeof err.stderr === "string") {
-    throw new CommandError(msg, err.stderr, { cause: err });
-  }
-  if (err instanceof Error) {
-    throw new Error(`${msg}\n${err.message}`, { cause: err });
-  }
-  throw new Error(`${msg}\n${String(err)}`, { cause: err });
+function concatBytes(acc: Uint8Array, curr: Uint8Array): Uint8Array {
+  const out = new Uint8Array(acc.length + curr.length);
+  out.set(acc);
+  out.set(curr, acc.length);
+  return out;
 }
 
 /**
- * 子プロセスを実行して標準出力を返します。
- * 失敗時は`CommandError`を投げます。
+ * 子プロセスを実行し、標準出力をtrim済みの文字列で返します。
+ * 終了コードが0以外の場合は標準エラー出力を含む`CommandFailedError`で失敗します。
  */
-export async function run(cmd: string, args: readonly string[]): Promise<string> {
-  try {
-    const { stdout } = await exec(cmd, args);
-    return stdout.trim();
-  } catch (err: unknown) {
-    throwCommandError(`Command failed: ${cmd} ${args.join(" ")}`, err);
-  }
+export function runStdout(
+  cmd: string,
+  args: readonly string[],
+): Effect.Effect<string, CommandFailedError | PlatformError, CommandExecutor> {
+  return Effect.scoped(
+    Effect.gen(function* () {
+      const process = yield* Command.start(Command.make(cmd, ...args));
+      const decoder = new TextDecoder();
+      const [stdoutBytes, stderrBytes, exitCode] = yield* Effect.all(
+        [
+          Stream.runFold(process.stdout, new Uint8Array(), concatBytes),
+          Stream.runFold(process.stderr, new Uint8Array(), concatBytes),
+          process.exitCode,
+        ],
+        { concurrency: "unbounded" },
+      );
+      if (exitCode !== 0) {
+        return yield* new CommandFailedError({
+          command: cmd,
+          args,
+          exitCode,
+          stderr: decoder.decode(stderrBytes).trim(),
+        });
+      }
+      return decoder.decode(stdoutBytes).trim();
+    }),
+  );
 }
 
 /**
- * `run`のエラーを握り潰すバリエーション。
+ * `runStdout`の失敗を握り潰す版です。
  * upstream未設定時の`git rev-parse @{u}`のように、
- * 失敗自体が情報を持つ呼び出しで使います。
+ * 失敗自体が情報として意味を持つ呼び出しで使います。
  */
-export async function tryRun(cmd: string, args: readonly string[]): Promise<string | undefined> {
-  try {
-    const { stdout } = await exec(cmd, args);
-    return stdout.trim();
-  } catch {
-    return undefined;
-  }
-}
-
-/**
- * `CommandError`/`Error`のいずれでも適切に文字列化します。
- * 子プロセス由来の場合は`stderr`が付加されます。
- */
-export function displayErrorMessage(err: unknown): string {
-  if (err instanceof CommandError) {
-    return err.stderr !== "" ? `${err.message}\n${err.stderr}` : err.message;
-  }
-  if (err instanceof Error) {
-    return err.message;
-  }
-  return String(err);
+export function tryRunStdout(
+  cmd: string,
+  args: readonly string[],
+): Effect.Effect<Option.Option<string>, PlatformError, CommandExecutor> {
+  return runStdout(cmd, args).pipe(
+    Effect.map(Option.some),
+    Effect.catchTag("CommandFailedError", () => Effect.succeed(Option.none<string>())),
+  );
 }

--- a/plugins/pr/src/sync-and-push.ts
+++ b/plugins/pr/src/sync-and-push.ts
@@ -37,7 +37,7 @@ export function syncAndPush(): Effect.Effect<
     const sync = yield* syncBase();
     const push = yield* pushHead();
     if (sync.currentBranch !== push.currentBranch) {
-      Effect.die("syncBase and pushHead returned results for different branches");
+      yield* Effect.die("syncBase and pushHead returned results for different branches");
     }
     return { ...sync, action: push.action };
   });

--- a/plugins/pr/src/sync-and-push.ts
+++ b/plugins/pr/src/sync-and-push.ts
@@ -36,6 +36,9 @@ export function syncAndPush(): Effect.Effect<
   return Effect.gen(function* () {
     const sync = yield* syncBase();
     const push = yield* pushHead();
+    if (sync.currentBranch !== push.currentBranch) {
+      Effect.die("syncBase and pushHead returned results for different branches");
+    }
     return { ...sync, action: push.action };
   });
 }

--- a/plugins/pr/src/sync-and-push.ts
+++ b/plugins/pr/src/sync-and-push.ts
@@ -1,9 +1,17 @@
-import { type PushHeadResult, pushHead } from "./push-head";
-import { type SyncBaseResult, syncBase } from "./sync-base";
+import type { CommandExecutor } from "@effect/platform/CommandExecutor";
+import type { PlatformError } from "@effect/platform/Error";
+import { Effect, type ParseResult } from "effect";
+import {
+  BehindUpstreamError,
+  ExistingOpenPullRequestError,
+  type PushHeadResult,
+  RevListParseError,
+  pushHead,
+} from "./push-head";
+import { CommandFailedError } from "./run";
+import { CurrentIsBaseError, RebaseFailedError, type SyncBaseResult, syncBase } from "./sync-base";
 
-/**
- * `syncBase`と`pushHead`の結果を1つにまとめた型。
- */
+/** `syncBase`と`pushHead`の結果を1つにまとめた型。 */
 export type SyncAndPushResult = SyncBaseResult & PushHeadResult;
 
 /**
@@ -13,10 +21,23 @@ export type SyncAndPushResult = SyncBaseResult & PushHeadResult;
  * かつ両方ともエラー時はPR作成スキルを終了するという挙動が共通しているため、
  * 1本のエントリーポイントにまとめます。
  */
-export async function syncAndPush(): Promise<SyncAndPushResult> {
-  const sync = await syncBase();
-  const push = await pushHead();
-  return { ...sync, action: push.action };
+export function syncAndPush(): Effect.Effect<
+  SyncAndPushResult,
+  | CommandFailedError
+  | PlatformError
+  | RevListParseError
+  | ParseResult.ParseError
+  | CurrentIsBaseError
+  | RebaseFailedError
+  | BehindUpstreamError
+  | ExistingOpenPullRequestError,
+  CommandExecutor
+> {
+  return Effect.gen(function* () {
+    const sync = yield* syncBase();
+    const push = yield* pushHead();
+    return { ...sync, action: push.action };
+  });
 }
 
 export function formatSyncAndPush(result: SyncAndPushResult): string {

--- a/plugins/pr/src/sync-base.ts
+++ b/plugins/pr/src/sync-base.ts
@@ -1,4 +1,7 @@
-import { CommandError, run, throwCommandError } from "./run";
+import type { CommandExecutor } from "@effect/platform/CommandExecutor";
+import type { PlatformError } from "@effect/platform/Error";
+import { Data, Effect, type ParseResult, Schema } from "effect";
+import { CommandFailedError, runStdout } from "./run";
 
 export interface SyncBaseResult {
   readonly currentBranch: string;
@@ -8,93 +11,137 @@ export interface SyncBaseResult {
   readonly rebased: boolean;
 }
 
-interface RepoInfo {
-  readonly owner: string;
-  readonly repo: string;
-  readonly baseBranch: string;
-}
-
-function parseRepoInfo(json: string): RepoInfo {
-  const value: unknown = JSON.parse(json);
-  if (
-    typeof value === "object" &&
-    value !== null &&
-    "owner" in value &&
-    typeof value.owner === "object" &&
-    value.owner !== null &&
-    "login" in value.owner &&
-    typeof value.owner.login === "string" &&
-    "name" in value &&
-    typeof value.name === "string" &&
-    "defaultBranchRef" in value &&
-    typeof value.defaultBranchRef === "object" &&
-    value.defaultBranchRef !== null &&
-    "name" in value.defaultBranchRef &&
-    typeof value.defaultBranchRef.name === "string"
-  ) {
-    return {
-      owner: value.owner.login,
-      repo: value.name,
-      baseBranch: value.defaultBranchRef.name,
-    };
-  }
-  throw new CommandError("Failed to parse gh repo view output.", json);
-}
-
 /**
- * baseブランチを最新化して、
- * 元のブランチに戻ってきます。
+ * `gh repo view --json owner,name,defaultBranchRef`の出力スキーマ。
+ *
+ * JSON文字列を受け取り、必要なフィールドだけを抽出した整形済みの`RepoInfo`へ変換します。
+ * `Schema.transform`でフィールド名の付け替えとネスト解決も一気に行います。
  */
-async function pullBase(baseBranch: string, currentBranch: string): Promise<void> {
-  try {
-    await run("git", ["switch", "--", baseBranch]);
-    await run("git", ["pull", "--ff-only"]);
-  } catch (err: unknown) {
-    throwCommandError(`Failed to update base branch ${baseBranch}.`, err);
-  } finally {
-    // エラーが起きてもできるだけ元のブランチに戻るようにします。
-    // ここでエラーが起きた場合は元のエラーは上書きしてしまいますが、
-    // それが起きる理由がクリティカルな問題が起きている時以外は考えにくいので、
-    // 考慮しません。
-    await run("git", ["switch", "--", currentBranch]);
+const RepoInfoFromJson = Schema.parseJson(
+  Schema.Struct({
+    owner: Schema.Struct({ login: Schema.String }),
+    name: Schema.String,
+    defaultBranchRef: Schema.Struct({ name: Schema.String }),
+  }),
+).pipe(
+  Schema.transform(
+    Schema.Struct({
+      owner: Schema.String,
+      repo: Schema.String,
+      baseBranch: Schema.String,
+    }),
+    {
+      strict: true,
+      decode: (raw) => ({
+        owner: raw.owner.login,
+        repo: raw.name,
+        baseBranch: raw.defaultBranchRef.name,
+      }),
+      encode: (info) => ({
+        owner: { login: info.owner },
+        name: info.repo,
+        defaultBranchRef: { name: info.baseBranch },
+      }),
+    },
+  ),
+);
+
+type RepoInfo = Schema.Schema.Type<typeof RepoInfoFromJson>;
+
+/** カレントブランチがbaseブランチと同じ場合に投げます。 */
+export class CurrentIsBaseError extends Data.TaggedError("CurrentIsBaseError")<{
+  readonly baseBranch: string;
+}> {
+  override get message(): string {
+    return `Current branch is the base branch ${this.baseBranch}.`;
+  }
+}
+
+/** rebaseが失敗してabortで巻き戻したことを表します。 */
+export class RebaseFailedError extends Data.TaggedError("RebaseFailedError")<{
+  readonly currentBranch: string;
+  readonly baseBranch: string;
+  readonly cause: CommandFailedError | PlatformError;
+}> {
+  override get message(): string {
+    return `Failed to rebase ${this.currentBranch} onto ${this.baseBranch}.\n${this.cause.message}`;
   }
 }
 
 /**
- * baseブランチを最新化して、
- * 必要に応じて現在のブランチをbaseの上にrebaseします。
+ * `gh repo view`が返したJSONをデコードして`RepoInfo`を返します。
+ *
+ * 検証とデコードを`Schema`に委ねるため、失敗時のエラー型は`ParseResult.ParseError`になります。
+ */
+export function parseRepoInfo(json: string): Effect.Effect<RepoInfo, ParseResult.ParseError> {
+  return Schema.decodeUnknown(RepoInfoFromJson)(json);
+}
+
+/**
+ * baseブランチを最新化して、元のブランチに戻ります。
+ *
+ * `git pull`に失敗してもできるだけ元のブランチに戻るため、
+ * `Effect.ensuring`で`git switch`をfinally相当として実行します。
+ */
+function pullBase(
+  baseBranch: string,
+  currentBranch: string,
+): Effect.Effect<void, CommandFailedError | PlatformError, CommandExecutor> {
+  return Effect.gen(function* () {
+    yield* runStdout("git", ["switch", "--", baseBranch]);
+    yield* runStdout("git", ["pull", "--ff-only"]);
+  }).pipe(Effect.ensuring(Effect.ignore(runStdout("git", ["switch", "--", currentBranch]))));
+}
+
+/**
+ * baseブランチを最新化して、必要に応じて現在のブランチをbaseの上にrebaseします。
  *
  * pushはこの関数では行いません。
  * upstreamの有無やrebaseの結果を踏まえたforce-with-leaseの判断は、
  * `pushHead`に委ねます。
  */
-export async function syncBase(): Promise<SyncBaseResult> {
-  const repoInfoJson = await run("gh", ["repo", "view", "--json", "owner,name,defaultBranchRef"]);
-  const { owner, repo, baseBranch } = parseRepoInfo(repoInfoJson);
-  const currentBranch = await run("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
+export function syncBase(): Effect.Effect<
+  SyncBaseResult,
+  | CommandFailedError
+  | PlatformError
+  | ParseResult.ParseError
+  | CurrentIsBaseError
+  | RebaseFailedError,
+  CommandExecutor
+> {
+  return Effect.gen(function* () {
+    const repoInfoJson = yield* runStdout("gh", [
+      "repo",
+      "view",
+      "--json",
+      "owner,name,defaultBranchRef",
+    ]);
+    const { owner, repo, baseBranch } = yield* parseRepoInfo(repoInfoJson);
+    const currentBranch = yield* runStdout("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
 
-  if (currentBranch === baseBranch) {
-    throw new CommandError(`Current branch is the base branch ${baseBranch}.`, "");
-  }
-
-  const initialBaseSha = await run("git", ["rev-parse", "--end-of-options", baseBranch]);
-  await pullBase(baseBranch, currentBranch);
-
-  const newBaseSha = await run("git", ["rev-parse", "--end-of-options", baseBranch]);
-  const rebased = initialBaseSha !== newBaseSha;
-  if (rebased) {
-    try {
-      await run("git", ["rebase", "--", baseBranch]);
-    } catch (err: unknown) {
-      // コンフリクト等でrebaseに失敗した場合、
-      // 中断状態を残さないように`git rebase --abort`で巻き戻してから例外を再構築します。
-      // `git rebase --abort`が失敗する可能性もありますが、
-      // その場合の方が問題なので、
-      // そちらの例外の表示を優先します。
-      await run("git", ["rebase", "--abort"]);
-      throwCommandError(`Failed to rebase ${currentBranch} onto ${baseBranch}.`, err);
+    if (currentBranch === baseBranch) {
+      return yield* new CurrentIsBaseError({ baseBranch });
     }
-  }
 
-  return { currentBranch, baseBranch, owner, repo, rebased };
+    const initialBaseSha = yield* runStdout("git", ["rev-parse", "--end-of-options", baseBranch]);
+    yield* pullBase(baseBranch, currentBranch);
+
+    const newBaseSha = yield* runStdout("git", ["rev-parse", "--end-of-options", baseBranch]);
+    const rebased = initialBaseSha !== newBaseSha;
+    if (rebased) {
+      yield* runStdout("git", ["rebase", "--", baseBranch]).pipe(
+        Effect.catchTags({
+          CommandFailedError: (err) =>
+            Effect.gen(function* () {
+              // コンフリクト等でrebaseに失敗した場合、
+              // 中断状態を残さないように`git rebase --abort`で巻き戻してから例外を再構築します。
+              yield* runStdout("git", ["rebase", "--abort"]);
+              return yield* new RebaseFailedError({ currentBranch, baseBranch, cause: err });
+            }),
+        }),
+      );
+    }
+
+    return { currentBranch, baseBranch, owner, repo, rebased };
+  });
 }

--- a/plugins/pr/test/konoka-editor.test.ts
+++ b/plugins/pr/test/konoka-editor.test.ts
@@ -1,0 +1,132 @@
+import { NodeContext } from "@effect/platform-node";
+import { describe, it } from "@effect/vitest";
+import { Cause, ConfigProvider, Effect, Exit, Option } from "effect";
+import { expect, test } from "vitest";
+import {
+  buildEditorInvocation,
+  defaultEditor,
+  editorCommand,
+  konokaEdit,
+} from "../src/konoka-editor";
+
+describe("buildEditorInvocation", () => {
+  test("`sh -c`経由のargvを生成する", () => {
+    expect(buildEditorInvocation("vim", "/tmp/file")).toEqual([
+      "sh",
+      "-c",
+      `vim "$@"`,
+      "konoka-editor",
+      "/tmp/file",
+    ]);
+  });
+
+  test("引数付きエディタ指定もそのままシェルスクリプトに埋め込む", () => {
+    expect(buildEditorInvocation("emacsclient --reuse-frame", "/tmp/file")).toEqual([
+      "sh",
+      "-c",
+      `emacsclient --reuse-frame "$@"`,
+      "konoka-editor",
+      "/tmp/file",
+    ]);
+  });
+
+  test("ファイルパスをスクリプト本体に埋め込まず位置引数として渡す", () => {
+    const argv = buildEditorInvocation("vim", "/tmp/file with space");
+    expect(argv[2]).toBe(`vim "$@"`);
+    expect(argv[2]).not.toContain("/tmp/file with space");
+    expect(argv[4]).toBe("/tmp/file with space");
+  });
+
+  test("シェル内`$0`にあたる位置に`konoka-editor`を渡す", () => {
+    const argv = buildEditorInvocation("vim", "/tmp/file");
+    expect(argv[3]).toBe("konoka-editor");
+  });
+
+  test("実行ファイルパスをクオートしたエディタ指定もそのまま渡す", () => {
+    const editor = `"/Applications/Visual Studio Code.app/Contents/MacOS/Electron" --wait`;
+    expect(buildEditorInvocation(editor, "/tmp/file")).toEqual([
+      "sh",
+      "-c",
+      `${editor} "$@"`,
+      "konoka-editor",
+      "/tmp/file",
+    ]);
+  });
+});
+
+describe("editorCommand", () => {
+  it.effect("`EDITOR`が設定されていればその値を返す", () =>
+    editorCommand.pipe(
+      Effect.tap((cmd) => {
+        expect(cmd).toBe("nano");
+      }),
+      Effect.withConfigProvider(ConfigProvider.fromMap(new Map([["EDITOR", "nano"]]))),
+    ),
+  );
+
+  it.effect("`EDITOR`に引数付きコマンドを設定してもそのまま返す", () =>
+    editorCommand.pipe(
+      Effect.tap((cmd) => {
+        expect(cmd).toBe("code --wait");
+      }),
+      Effect.withConfigProvider(ConfigProvider.fromMap(new Map([["EDITOR", "code --wait"]]))),
+    ),
+  );
+
+  it.effect("`EDITOR`が未設定の場合はデフォルトを返す", () =>
+    editorCommand.pipe(
+      Effect.tap((cmd) => {
+        expect(cmd).toBe(defaultEditor);
+      }),
+      Effect.withConfigProvider(ConfigProvider.fromMap(new Map())),
+    ),
+  );
+
+  it.effect("`EDITOR`が空文字列の場合もデフォルトを返す", () =>
+    editorCommand.pipe(
+      Effect.tap((cmd) => {
+        expect(cmd).toBe(defaultEditor);
+      }),
+      Effect.withConfigProvider(ConfigProvider.fromMap(new Map([["EDITOR", ""]]))),
+    ),
+  );
+});
+
+describe("konokaEdit", () => {
+  it.effect("`EDITOR`が0で終わる場合は成功する", () =>
+    konokaEdit("/tmp/konoka-editor-test-arg").pipe(
+      Effect.withConfigProvider(ConfigProvider.fromMap(new Map([["EDITOR", "true"]]))),
+      Effect.provide(NodeContext.layer),
+    ),
+  );
+
+  it.effect("`EDITOR`が非0で終わる場合は終了コードを含むdefectで死ぬ", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(konokaEdit("/tmp/konoka-editor-test-arg"));
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        const defect = Cause.dieOption(exit.cause);
+        expect(Option.isSome(defect)).toBe(true);
+        if (Option.isSome(defect)) {
+          expect(String(defect.value)).toContain(
+            `EditorFailedError: Editor command "false" failed with exit code 1.`,
+          );
+        }
+      }
+    }).pipe(
+      Effect.withConfigProvider(ConfigProvider.fromMap(new Map([["EDITOR", "false"]]))),
+      Effect.provide(NodeContext.layer),
+    ),
+  );
+
+  it.effect("引数のファイルパスが`$1`としてエディタに渡る", () => {
+    // 内側に`sh -c`をもう一段噛ませることで、`"$@"`を素直な位置引数として受け取り、
+    // `$1`が`konokaEdit`に渡したファイルパスと一致するかを終了コードで判定します。
+    const arg = "/tmp/konoka-editor-passthrough-test";
+    const editor = `sh -c 'test "$1" = "${arg}"' --`;
+    return konokaEdit(arg).pipe(
+      Effect.withConfigProvider(ConfigProvider.fromMap(new Map([["EDITOR", editor]]))),
+      Effect.provide(NodeContext.layer),
+    );
+  });
+});

--- a/plugins/pr/test/prepare-editmsg.test.ts
+++ b/plugins/pr/test/prepare-editmsg.test.ts
@@ -1,7 +1,10 @@
 import { mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { NodeContext } from "@effect/platform-node";
+import { describe, it } from "@effect/vitest";
+import { Effect } from "effect";
+import { afterEach, beforeEach, expect } from "vitest";
 import { prepareEditmsg } from "../src/prepare-editmsg";
 
 describe("prepareEditmsg", () => {
@@ -15,28 +18,42 @@ describe("prepareEditmsg", () => {
     await rm(runtimeDir, { recursive: true, force: true });
   });
 
-  test("PULLREQ_EDITMSGファイルのパスを返します", async () => {
-    const path = await prepareEditmsg({ runtimeDir });
-    expect(path.endsWith("/PULLREQ_EDITMSG")).toBe(true);
-  });
+  it.effect("PULLREQ_EDITMSGファイルのパスを返す", () =>
+    prepareEditmsg({ runtimeDir }).pipe(
+      Effect.tap((path) => {
+        expect(path.endsWith("/PULLREQ_EDITMSG")).toBe(true);
+      }),
+      Effect.provide(NodeContext.layer),
+    ),
+  );
 
-  test("セッション固有のサブディレクトリを実体として作成します", async () => {
-    const path = await prepareEditmsg({ runtimeDir });
-    const info = await stat(dirname(path));
-    expect(info.isDirectory()).toBe(true);
-  });
+  it.effect("セッション固有のサブディレクトリを実体として作成する", () =>
+    prepareEditmsg({ runtimeDir }).pipe(
+      Effect.tap((path) =>
+        Effect.promise(async () => {
+          const info = await stat(dirname(path));
+          expect(info.isDirectory()).toBe(true);
+        }),
+      ),
+      Effect.provide(NodeContext.layer),
+    ),
+  );
 
-  test("複数回呼び出しても異なるディレクトリを返します", async () => {
-    const a = await prepareEditmsg({ runtimeDir });
-    const b = await prepareEditmsg({ runtimeDir });
-    expect(dirname(a)).not.toBe(dirname(b));
-  });
+  it.effect("複数回呼び出しても異なるディレクトリを返す", () =>
+    Effect.gen(function* () {
+      const a = yield* prepareEditmsg({ runtimeDir });
+      const b = yield* prepareEditmsg({ runtimeDir });
+      expect(dirname(a)).not.toBe(dirname(b));
+    }).pipe(Effect.provide(NodeContext.layer)),
+  );
 
-  test("基底ディレクトリが存在しなくても再帰的に作成します", async () => {
-    const fresh = join(runtimeDir, "fresh");
-    const path = await prepareEditmsg({ runtimeDir: fresh });
-    expect(path.startsWith(fresh)).toBe(true);
-    const info = await stat(dirname(path));
-    expect(info.isDirectory()).toBe(true);
-  });
+  it.effect("基底ディレクトリが存在しなくても再帰的に作成する", () =>
+    Effect.gen(function* () {
+      const fresh = join(runtimeDir, "fresh");
+      const path = yield* prepareEditmsg({ runtimeDir: fresh });
+      expect(path.startsWith(fresh)).toBe(true);
+      const info = yield* Effect.promise(() => stat(dirname(path)));
+      expect(info.isDirectory()).toBe(true);
+    }).pipe(Effect.provide(NodeContext.layer)),
+  );
 });

--- a/plugins/pr/test/push-head.test.ts
+++ b/plugins/pr/test/push-head.test.ts
@@ -1,41 +1,68 @@
-import { describe, expect, it } from "vitest";
-import { parseAheadBehind, parseOpenPr } from "../src/push-head";
-import { CommandError } from "../src/run";
+import { Cause, Effect, Exit, Option, ParseResult } from "effect";
+import { describe, expect, test } from "vitest";
+import { parseAheadBehind, parseOpenPr, RevListParseError } from "../src/push-head";
 
 describe("parseAheadBehind", () => {
-  it("git rev-list --left-right --countの出力をパースします", () => {
-    expect(parseAheadBehind("0\t3")).toEqual({ behind: 0, ahead: 3 });
-    expect(parseAheadBehind("2\t5")).toEqual({ behind: 2, ahead: 5 });
+  test("git rev-list --left-right --countの出力をパースする", () => {
+    expect(Effect.runSync(parseAheadBehind("0\t3"))).toEqual({ behind: 0, ahead: 3 });
+    expect(Effect.runSync(parseAheadBehind("2\t5"))).toEqual({ behind: 2, ahead: 5 });
   });
 
-  it("空白区切り(スペース)でもパースします", () => {
-    expect(parseAheadBehind("1 2")).toEqual({ behind: 1, ahead: 2 });
+  test("空白区切り(スペース)でもパースする", () => {
+    expect(Effect.runSync(parseAheadBehind("1 2"))).toEqual({ behind: 1, ahead: 2 });
   });
 
-  it("不正な出力では例外を投げます", () => {
-    expect(() => parseAheadBehind("foo")).toThrow(CommandError);
-    expect(() => parseAheadBehind("1\tbar")).toThrow(CommandError);
+  test("不正な出力は`RevListParseError`で失敗する", () => {
+    const exit = Effect.runSyncExit(parseAheadBehind("foo"));
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const failure = Cause.failureOption(exit.cause);
+      expect(Option.isSome(failure) && failure.value instanceof RevListParseError).toBe(true);
+    }
+  });
+
+  test("片方が数値でない場合も`RevListParseError`で失敗する", () => {
+    const exit = Effect.runSyncExit(parseAheadBehind("1\tbar"));
+    expect(Exit.isFailure(exit)).toBe(true);
   });
 });
 
 describe("parseOpenPr", () => {
-  it("空配列の場合はundefinedを返します", () => {
-    expect(parseOpenPr("[]")).toBeUndefined();
+  test("空配列の場合は`Option.none`を返す", () => {
+    expect(Effect.runSync(parseOpenPr("[]"))).toEqual(Option.none());
   });
 
-  it("PR番号を取り出します", () => {
-    expect(parseOpenPr('[{"number":42}]')).toEqual({ number: 42 });
+  test("PR番号を取り出す", () => {
+    expect(Effect.runSync(parseOpenPr('[{"number":42}]'))).toEqual(Option.some({ number: 42 }));
   });
 
-  it("複数件あっても先頭1件を返します", () => {
-    expect(parseOpenPr('[{"number":1},{"number":2}]')).toEqual({ number: 1 });
+  test("複数件あっても先頭1件を返す", () => {
+    expect(Effect.runSync(parseOpenPr('[{"number":1},{"number":2}]'))).toEqual(
+      Option.some({ number: 1 }),
+    );
   });
 
-  it("number以外のフィールドが入っていても無視されます", () => {
-    expect(parseOpenPr('[{"number":7,"title":"x"}]')).toEqual({ number: 7 });
+  test("number以外のフィールドが入っていても無視される", () => {
+    expect(Effect.runSync(parseOpenPr('[{"number":7,"title":"x"}]'))).toEqual(
+      Option.some({ number: 7 }),
+    );
   });
 
-  it("numberが数値でない場合は例外を投げます", () => {
-    expect(() => parseOpenPr('[{"number":"42"}]')).toThrow(CommandError);
+  test("numberが数値でない場合は`Schema`の`ParseError`で失敗する", () => {
+    const exit = Effect.runSyncExit(parseOpenPr('[{"number":"42"}]'));
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const failure = Cause.failureOption(exit.cause);
+      expect(Option.isSome(failure) && ParseResult.isParseError(failure.value)).toBe(true);
+    }
+  });
+
+  test("JSONとしてパースできない文字列も`Schema`の`ParseError`で失敗する", () => {
+    const exit = Effect.runSyncExit(parseOpenPr("not json"));
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const failure = Cause.failureOption(exit.cause);
+      expect(Option.isSome(failure) && ParseResult.isParseError(failure.value)).toBe(true);
+    }
   });
 });

--- a/plugins/pr/test/read-contributing.test.ts
+++ b/plugins/pr/test/read-contributing.test.ts
@@ -1,7 +1,10 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { NodeContext } from "@effect/platform-node";
+import { describe, it } from "@effect/vitest";
+import { Effect, Option } from "effect";
+import { afterEach, beforeEach, expect, test } from "vitest";
 import { formatContributing, readContributing } from "../src/read-contributing";
 
 describe("readContributing", () => {
@@ -15,38 +18,59 @@ describe("readContributing", () => {
     await rm(root, { recursive: true, force: true });
   });
 
-  test("CONTRIBUTING.mdが存在しない場合はundefinedを返します", async () => {
-    expect(await readContributing(root)).toBeUndefined();
-  });
+  it.effect("CONTRIBUTING.mdが存在しない場合は`Option.none`を返す", () =>
+    readContributing(root).pipe(
+      Effect.tap((result) => {
+        expect(Option.isNone(result)).toBe(true);
+      }),
+      Effect.provide(NodeContext.layer),
+    ),
+  );
 
-  test("リポジトリ直下のCONTRIBUTING.mdを読み込みます", async () => {
-    await writeFile(join(root, "CONTRIBUTING.md"), "# direct\n");
-    expect(await readContributing(root)).toEqual({
-      path: "CONTRIBUTING.md",
-      content: "# direct\n",
-    });
-  });
+  it.effect("リポジトリ直下のCONTRIBUTING.mdを読み込む", () =>
+    Effect.gen(function* () {
+      yield* Effect.promise(() => writeFile(join(root, "CONTRIBUTING.md"), "# direct\n"));
+      const result = yield* readContributing(root);
+      expect(result).toEqual(
+        Option.some({
+          path: "CONTRIBUTING.md",
+          content: "# direct\n",
+        }),
+      );
+    }).pipe(Effect.provide(NodeContext.layer)),
+  );
 
-  test(".github/CONTRIBUTING.mdを読み込みます", async () => {
-    await mkdir(join(root, ".github"));
-    await writeFile(join(root, ".github/CONTRIBUTING.md"), "# github dir\n");
-    expect(await readContributing(root)).toEqual({
-      path: ".github/CONTRIBUTING.md",
-      content: "# github dir\n",
-    });
-  });
+  it.effect(".github/CONTRIBUTING.mdを読み込む", () =>
+    Effect.gen(function* () {
+      yield* Effect.promise(() => mkdir(join(root, ".github")));
+      yield* Effect.promise(() =>
+        writeFile(join(root, ".github/CONTRIBUTING.md"), "# github dir\n"),
+      );
+      const result = yield* readContributing(root);
+      expect(result).toEqual(
+        Option.some({
+          path: ".github/CONTRIBUTING.md",
+          content: "# github dir\n",
+        }),
+      );
+    }).pipe(Effect.provide(NodeContext.layer)),
+  );
 
-  test("複数候補が存在する場合は.github/CONTRIBUTING.mdを優先します", async () => {
-    await mkdir(join(root, ".github"));
-    await writeFile(join(root, "CONTRIBUTING.md"), "# direct\n");
-    await writeFile(join(root, ".github/CONTRIBUTING.md"), "# github dir\n");
-    const file = await readContributing(root);
-    expect(file?.path).toBe(".github/CONTRIBUTING.md");
-  });
+  it.effect("複数候補が存在する場合は.github/CONTRIBUTING.mdを優先する", () =>
+    Effect.gen(function* () {
+      yield* Effect.promise(() => mkdir(join(root, ".github")));
+      yield* Effect.promise(() => writeFile(join(root, "CONTRIBUTING.md"), "# direct\n"));
+      yield* Effect.promise(() =>
+        writeFile(join(root, ".github/CONTRIBUTING.md"), "# github dir\n"),
+      );
+      const result = yield* readContributing(root);
+      expect(Option.isSome(result) && result.value.path).toBe(".github/CONTRIBUTING.md");
+    }).pipe(Effect.provide(NodeContext.layer)),
+  );
 });
 
 describe("formatContributing", () => {
-  test("ファイルパスを見出しとして整形します", () => {
+  test("ファイルパスを見出しとして整形する", () => {
     expect(formatContributing({ path: "CONTRIBUTING.md", content: "body\n" })).toBe(
       "# CONTRIBUTING.md\n\nbody\n",
     );

--- a/plugins/pr/test/read-pull-request-template.test.ts
+++ b/plugins/pr/test/read-pull-request-template.test.ts
@@ -1,7 +1,10 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { NodeContext } from "@effect/platform-node";
+import { describe, it } from "@effect/vitest";
+import { Effect } from "effect";
+import { afterEach, beforeEach, expect, test } from "vitest";
 import {
   formatPullRequestTemplates,
   readPullRequestTemplates,
@@ -18,44 +21,72 @@ describe("readPullRequestTemplates", () => {
     await rm(root, { recursive: true, force: true });
   });
 
-  test("テンプレートが存在しない場合は空配列を返します", async () => {
-    expect(await readPullRequestTemplates(root)).toEqual([]);
-  });
+  it.effect("テンプレートが存在しない場合は空配列を返す", () =>
+    readPullRequestTemplates(root).pipe(
+      Effect.tap((templates) => {
+        expect(templates).toEqual([]);
+      }),
+      Effect.provide(NodeContext.layer),
+    ),
+  );
 
-  test(".github/pull_request_template.mdを読み込みます", async () => {
-    await mkdir(join(root, ".github"));
-    await writeFile(join(root, ".github/pull_request_template.md"), "default body\n");
-    expect(await readPullRequestTemplates(root)).toEqual([
-      { path: ".github/pull_request_template.md", content: "default body\n" },
-    ]);
-  });
+  it.effect(".github/pull_request_template.mdを読み込む", () =>
+    Effect.gen(function* () {
+      yield* Effect.promise(() => mkdir(join(root, ".github")));
+      yield* Effect.promise(() =>
+        writeFile(join(root, ".github/pull_request_template.md"), "default body\n"),
+      );
+      const templates = yield* readPullRequestTemplates(root);
+      expect(templates).toEqual([
+        { path: ".github/pull_request_template.md", content: "default body\n" },
+      ]);
+    }).pipe(Effect.provide(NodeContext.layer)),
+  );
 
-  test("PULL_REQUEST_TEMPLATEディレクトリ配下の.mdファイルを全て読み込みます", async () => {
-    await mkdir(join(root, ".github/PULL_REQUEST_TEMPLATE"), { recursive: true });
-    await writeFile(join(root, ".github/PULL_REQUEST_TEMPLATE/bug.md"), "bug template\n");
-    await writeFile(join(root, ".github/PULL_REQUEST_TEMPLATE/feature.md"), "feature template\n");
-    await writeFile(join(root, ".github/PULL_REQUEST_TEMPLATE/skip.txt"), "ignored\n");
+  it.effect("PULL_REQUEST_TEMPLATEディレクトリ配下の.mdファイルを全て読み込む", () =>
+    Effect.gen(function* () {
+      yield* Effect.promise(() =>
+        mkdir(join(root, ".github/PULL_REQUEST_TEMPLATE"), { recursive: true }),
+      );
+      yield* Effect.promise(() =>
+        writeFile(join(root, ".github/PULL_REQUEST_TEMPLATE/bug.md"), "bug template\n"),
+      );
+      yield* Effect.promise(() =>
+        writeFile(join(root, ".github/PULL_REQUEST_TEMPLATE/feature.md"), "feature template\n"),
+      );
+      yield* Effect.promise(() =>
+        writeFile(join(root, ".github/PULL_REQUEST_TEMPLATE/skip.txt"), "ignored\n"),
+      );
 
-    const templates = await readPullRequestTemplates(root);
-    const paths = templates.map((t) => t.path).sort();
-    expect(paths).toEqual([
-      ".github/PULL_REQUEST_TEMPLATE/bug.md",
-      ".github/PULL_REQUEST_TEMPLATE/feature.md",
-    ]);
-  });
+      const templates = yield* readPullRequestTemplates(root);
+      const paths = templates.map((t) => t.path).sort();
+      expect(paths).toEqual([
+        ".github/PULL_REQUEST_TEMPLATE/bug.md",
+        ".github/PULL_REQUEST_TEMPLATE/feature.md",
+      ]);
+    }).pipe(Effect.provide(NodeContext.layer)),
+  );
 
-  test("単一テンプレートと複数テンプレートが両方ある場合は全てを返します", async () => {
-    await mkdir(join(root, ".github/PULL_REQUEST_TEMPLATE"), { recursive: true });
-    await writeFile(join(root, ".github/pull_request_template.md"), "default\n");
-    await writeFile(join(root, ".github/PULL_REQUEST_TEMPLATE/bug.md"), "bug\n");
+  it.effect("単一テンプレートと複数テンプレートが両方ある場合は全てを返す", () =>
+    Effect.gen(function* () {
+      yield* Effect.promise(() =>
+        mkdir(join(root, ".github/PULL_REQUEST_TEMPLATE"), { recursive: true }),
+      );
+      yield* Effect.promise(() =>
+        writeFile(join(root, ".github/pull_request_template.md"), "default\n"),
+      );
+      yield* Effect.promise(() =>
+        writeFile(join(root, ".github/PULL_REQUEST_TEMPLATE/bug.md"), "bug\n"),
+      );
 
-    const templates = await readPullRequestTemplates(root);
-    expect(templates).toHaveLength(2);
-  });
+      const templates = yield* readPullRequestTemplates(root);
+      expect(templates).toHaveLength(2);
+    }).pipe(Effect.provide(NodeContext.layer)),
+  );
 });
 
 describe("formatPullRequestTemplates", () => {
-  test("各テンプレートを区切り線で連結します", () => {
+  test("各テンプレートを区切り線で連結する", () => {
     const result = formatPullRequestTemplates([
       { path: "a.md", content: "A\n" },
       { path: "b.md", content: "B\n" },
@@ -63,7 +94,7 @@ describe("formatPullRequestTemplates", () => {
     expect(result).toBe("# a.md\n\nA\n\n\n---\n\n# b.md\n\nB\n");
   });
 
-  test("空配列の場合は空文字列を返します", () => {
+  test("空配列の場合は空文字列を返す", () => {
     expect(formatPullRequestTemplates([])).toBe("");
   });
 });

--- a/plugins/pr/test/sync-base.test.ts
+++ b/plugins/pr/test/sync-base.test.ts
@@ -1,0 +1,51 @@
+import { Cause, Effect, Exit, Option, ParseResult } from "effect";
+import { describe, expect, test } from "vitest";
+import { parseRepoInfo } from "../src/sync-base";
+
+describe("parseRepoInfo", () => {
+  test("gh repo viewのJSONをデコードしてowner/repo/baseBranchを取り出す", () => {
+    const json = JSON.stringify({
+      owner: { login: "ncaq" },
+      name: "konoka",
+      defaultBranchRef: { name: "master" },
+    });
+    expect(Effect.runSync(parseRepoInfo(json))).toEqual({
+      owner: "ncaq",
+      repo: "konoka",
+      baseBranch: "master",
+    });
+  });
+
+  test("必須フィールドが欠けている場合は`Schema`の`ParseError`で失敗する", () => {
+    const json = JSON.stringify({ owner: { login: "ncaq" }, name: "konoka" });
+    const exit = Effect.runSyncExit(parseRepoInfo(json));
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const failure = Cause.failureOption(exit.cause);
+      expect(Option.isSome(failure) && ParseResult.isParseError(failure.value)).toBe(true);
+    }
+  });
+
+  test("フィールド型が違う場合も`Schema`の`ParseError`で失敗する", () => {
+    const json = JSON.stringify({
+      owner: { login: 123 },
+      name: "konoka",
+      defaultBranchRef: { name: "master" },
+    });
+    const exit = Effect.runSyncExit(parseRepoInfo(json));
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const failure = Cause.failureOption(exit.cause);
+      expect(Option.isSome(failure) && ParseResult.isParseError(failure.value)).toBe(true);
+    }
+  });
+
+  test("JSONとしてパースできない文字列も`Schema`の`ParseError`で失敗する", () => {
+    const exit = Effect.runSyncExit(parseRepoInfo("not json"));
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const failure = Cause.failureOption(exit.cause);
+      expect(Option.isSome(failure) && ParseResult.isParseError(failure.value)).toBe(true);
+    }
+  });
+});

--- a/plugins/pr/tsconfig.json
+++ b/plugins/pr/tsconfig.json
@@ -66,7 +66,13 @@
      */
     // 明示的にimportしなくても有効になる`@types/*`の対象を設定できます。
     // ここに列挙されたものだけ暗黙時に有効になります。
-    "types": ["node"]
+    "types": ["node"],
+    // プラグイン。
+    "plugins": [
+      {
+        "name": "@effect/language-service"
+      }
+    ]
   },
   // コンパイル対象から除外するパスのglobパターンを記述できます。
   "exclude": ["node_modules", "dist", "result", "result-*"]


### PR DESCRIPTION
`pr`プラグインの以下の補助プログラム、

- `prepare-editmsg`
- `read-contributing`
- `read-pull-request-template`
- `sync-and-push`
- `konoka-editor`

と共通モジュール群を、
Effectベースの宣言的記述に書き換えます。
`commit`プラグインで先行して整備したEffect化の構造に揃え、
副作用・引数処理・終了コード・JSONパースの全てを、
Effectのruntimeとサービス層に委ねる形にします。

主な成果は以下です。

- `effect`/`@effect/platform`/`@effect/platform-node`/`@effect/cli`を依存に追加し、
  開発依存に`@effect/vitest`/`@effect/language-service`を追加。
  `vitest`は`commit`に合わせて3系に戻してEffect系の整合性を確保
- `read-if-exists`/`read-contributing`/`read-pull-request-template`/`prepare-editmsg`を、
  `FileSystem`/`Path`/`Config`経由の宣言的記述に統一し、
  `Option`ベースの不在表現に変更
- 旧`run.ts`の`CommandError` + execFile構成を撤廃し、
  `Command.start` + `Stream.runFold` + `Process.exitCode`の組み合わせを`runStdout`/`tryRunStdout`に集約。
  失敗は`CommandFailedError`タグ付きエラーで表現
- `push-head`/`sync-base`/`sync-and-push`をEffect化し、想定される失敗を以下のタグ付きエラーに分解。
  `RevListParseError`、
  `BehindUpstreamError`、
  `ExistingOpenPullRequestError`、
  `CurrentIsBaseError`、
  `RebaseFailedError`
- `parseOpenPr`と`parseRepoInfo`を`Schema.parseJson` + `Schema.Struct` (+ `Schema.transform`)で組み立て、
  JSONパース・型検査・フィールド付け替えを単一の宣言にまとめて`ParseResult.ParseError`に統一
- `konoka-editor`を`commit`と同じ`buildEditorInvocation` + `editorCommand` + `konokaEdit`構成に書き換え、
  `@effect/cli`の`Args.file({ name: "PULLREQ_EDITMSG", exists: "yes" })`で引数を宣言
- 各CLIエントリを`NodeRuntime.runMain` + `NodeContext.layer`化。
  `sync-and-push`は`disableErrorReporting`と`tapError(err.message)` + `teardown`で終了コードを集中管理
- 既存テストを`@effect/vitest`の`it.effect`と`ConfigProvider.fromMap`ベースに更新。
  `konoka-editor`と`sync-base`の`parseRepoInfo`にテストを新規追加

CLIの入出力と終了コードの仕様は維持しているため、
ユーザ向けの挙動には影響しません。
