### PR TITLE
build(deps-dev): deprecatedな`@eslint/compat`から`eslint/config`に移行

### DIFF
--- a/plugins/commit/eslint.config.ts
+++ b/plugins/commit/eslint.config.ts
@@ -1,8 +1,7 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { includeIgnoreFile } from "@eslint/compat";
 import { configs as eslintConfigs } from "@eslint/js";
-import { defineConfig } from "eslint/config";
+import { defineConfig, includeIgnoreFile } from "eslint/config";
 import eslintConfigPrettier from "eslint-config-prettier";
 import { createTypeScriptImportResolver } from "eslint-import-resolver-typescript";
 import { flatConfigs as importPluginConfig } from "eslint-plugin-import-x";
@@ -19,7 +18,10 @@ const gitignorePath: string = path.resolve(__dirname, "../", "../", ".gitignore"
 /** ESLintが使用する設定を定義。 */
 const config: ReturnType<typeof defineConfig> = defineConfig(
   // どのプロジェクトでも共通して適用するルール。
-  includeIgnoreFile(gitignorePath), // .gitignoreから無視するべきファイルを継承。
+  // `.gitignore`から無視するべきファイルを継承。
+  // `gitignoreResolution: true`でignoreファイル自身からの相対パスとして解決する、
+  // 本来のgitignore挙動にします。
+  includeIgnoreFile(gitignorePath, { gitignoreResolution: true }),
   eslintConfigPrettier, // prettierと競合しないようにします。
   importPluginConfig.recommended, // importの推奨プリセット。
   importPluginConfig.typescript, // importのTypeScript向け推奨プリセット。

--- a/plugins/commit/package-lock.json
+++ b/plugins/commit/package-lock.json
@@ -14,7 +14,6 @@
       "devDependencies": {
         "@effect/language-service": "0.86.1",
         "@effect/vitest": "0.29.0",
-        "@eslint/compat": "2.1.0",
         "@eslint/js": "10.0.1",
         "@types/node": "22.19.19",
         "eslint": "10.4.0",
@@ -757,27 +756,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@eslint/compat": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-2.1.0.tgz",
-      "integrity": "sha512-LgaSCymEpw7tF53xvDw9SNsraPb1IBHxpdABIOM0hW8UAlP8znrjYtuxfR58FSJ3L9BhwD+FaPRFQpZq84Nh6g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^1.2.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "peerDependencies": {
-        "eslint": "^8.40 || 9 || 10"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
       }
     },
     "node_modules/@eslint/config-array": {

--- a/plugins/commit/package.json
+++ b/plugins/commit/package.json
@@ -22,7 +22,6 @@
   "devDependencies": {
     "@effect/language-service": "0.86.1",
     "@effect/vitest": "0.29.0",
-    "@eslint/compat": "2.1.0",
     "@eslint/js": "10.0.1",
     "@types/node": "22.19.19",
     "eslint": "10.4.0",

--- a/plugins/kyosei/eslint.config.ts
+++ b/plugins/kyosei/eslint.config.ts
@@ -1,8 +1,7 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { includeIgnoreFile } from "@eslint/compat";
 import { configs as eslintConfigs } from "@eslint/js";
-import { defineConfig } from "eslint/config";
+import { defineConfig, includeIgnoreFile } from "eslint/config";
 import eslintConfigPrettier from "eslint-config-prettier";
 import { createTypeScriptImportResolver } from "eslint-import-resolver-typescript";
 import { flatConfigs as importPluginConfig } from "eslint-plugin-import-x";
@@ -19,7 +18,10 @@ const gitignorePath: string = path.resolve(__dirname, "../", "../", ".gitignore"
 /** ESLintが使用する設定を定義。 */
 const config: ReturnType<typeof defineConfig> = defineConfig(
   // どのプロジェクトでも共通して適用するルール。
-  includeIgnoreFile(gitignorePath), // .gitignoreから無視するべきファイルを継承。
+  // `.gitignore`から無視するべきファイルを継承。
+  // `gitignoreResolution: true`でignoreファイル自身からの相対パスとして解決する、
+  // 本来のgitignore挙動にします。
+  includeIgnoreFile(gitignorePath, { gitignoreResolution: true }),
   eslintConfigPrettier, // prettierと競合しないようにします。
   importPluginConfig.recommended, // importの推奨プリセット。
   importPluginConfig.typescript, // importのTypeScript向け推奨プリセット。

--- a/plugins/kyosei/package-lock.json
+++ b/plugins/kyosei/package-lock.json
@@ -20,7 +20,6 @@
       "devDependencies": {
         "@effect/language-service": "0.85.1",
         "@effect/vitest": "0.29.0",
-        "@eslint/compat": "2.1.0",
         "@eslint/js": "10.0.1",
         "@types/mustache": "4.2.6",
         "@types/node": "20.19.40",
@@ -788,27 +787,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@eslint/compat": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-2.1.0.tgz",
-      "integrity": "sha512-LgaSCymEpw7tF53xvDw9SNsraPb1IBHxpdABIOM0hW8UAlP8znrjYtuxfR58FSJ3L9BhwD+FaPRFQpZq84Nh6g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^1.2.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "peerDependencies": {
-        "eslint": "^8.40 || 9 || 10"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
       }
     },
     "node_modules/@eslint/config-array": {

--- a/plugins/kyosei/package.json
+++ b/plugins/kyosei/package.json
@@ -29,7 +29,6 @@
   "devDependencies": {
     "@effect/language-service": "0.85.1",
     "@effect/vitest": "0.29.0",
-    "@eslint/compat": "2.1.0",
     "@eslint/js": "10.0.1",
     "@types/mustache": "4.2.6",
     "@types/node": "20.19.40",

--- a/plugins/pr/eslint.config.ts
+++ b/plugins/pr/eslint.config.ts
@@ -1,8 +1,7 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { includeIgnoreFile } from "@eslint/compat";
 import { configs as eslintConfigs } from "@eslint/js";
-import { defineConfig } from "eslint/config";
+import { defineConfig, includeIgnoreFile } from "eslint/config";
 import eslintConfigPrettier from "eslint-config-prettier";
 import { createTypeScriptImportResolver } from "eslint-import-resolver-typescript";
 import { flatConfigs as importPluginConfig } from "eslint-plugin-import-x";
@@ -19,7 +18,10 @@ const gitignorePath: string = path.resolve(__dirname, "../", "../", ".gitignore"
 /** ESLintが使用する設定を定義。 */
 const config: ReturnType<typeof defineConfig> = defineConfig(
   // どのプロジェクトでも共通して適用するルール。
-  includeIgnoreFile(gitignorePath), // .gitignoreから無視するべきファイルを継承。
+  // `.gitignore`から無視するべきファイルを継承。
+  // `gitignoreResolution: true`でignoreファイル自身からの相対パスとして解決する、
+  // 本来のgitignore挙動にします。
+  includeIgnoreFile(gitignorePath, { gitignoreResolution: true }),
   eslintConfigPrettier, // prettierと競合しないようにします。
   importPluginConfig.recommended, // importの推奨プリセット。
   importPluginConfig.typescript, // importのTypeScript向け推奨プリセット。

--- a/plugins/pr/package-lock.json
+++ b/plugins/pr/package-lock.json
@@ -14,7 +14,6 @@
       "devDependencies": {
         "@effect/language-service": "0.86.1",
         "@effect/vitest": "0.29.0",
-        "@eslint/compat": "2.1.0",
         "@eslint/js": "10.0.1",
         "@types/node": "22.19.19",
         "eslint": "10.4.0",
@@ -757,27 +756,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@eslint/compat": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-2.1.0.tgz",
-      "integrity": "sha512-LgaSCymEpw7tF53xvDw9SNsraPb1IBHxpdABIOM0hW8UAlP8znrjYtuxfR58FSJ3L9BhwD+FaPRFQpZq84Nh6g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^1.2.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "peerDependencies": {
-        "eslint": "^8.40 || 9 || 10"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
       }
     },
     "node_modules/@eslint/config-array": {

--- a/plugins/pr/package.json
+++ b/plugins/pr/package.json
@@ -22,7 +22,6 @@
   "devDependencies": {
     "@effect/language-service": "0.86.1",
     "@effect/vitest": "0.29.0",
-    "@eslint/compat": "2.1.0",
     "@eslint/js": "10.0.1",
     "@types/node": "22.19.19",
     "eslint": "10.4.0",


### PR DESCRIPTION
`@eslint/compat`の`includeIgnoreFile`は、
[eslint/rewrite#329](https://github.com/eslint/rewrite/issues/329)
でdeprecatedとなり、
`@eslint/config-helpers`(`eslint/config`から再エクスポート)への移行が公式に推奨されました。
これに従い各プラグインでimport元を切り替えます。

副次的な変更:

- 新APIで導入された`gitignoreResolution: true`を指定します。
  これによりignoreパターンをignoreファイル自身からの相対パスとして解決する本来のgitignore挙動になり、
  モノレポ等でサブディレクトリの`.gitignore`を扱う際の挙動が改善されます。
- 直接の依存先が無くなったため、`@eslint/compat`を各プラグインの`devDependencies`から削除しました。
  `eslint`は既に`10.4.0`なので追加のバージョン更新は不要です。
