### PR TITLE
refactor: 定数の命名規則を一貫して小文字キャメルケースに統一

### DIFF
--- a/plugins/commit/src/read-commit-instructions.ts
+++ b/plugins/commit/src/read-commit-instructions.ts
@@ -2,7 +2,7 @@ import { FileSystem } from "@effect/platform";
 import type { PlatformError } from "@effect/platform/Error";
 import { Effect, Option } from "effect";
 
-const COMMIT_INSTRUCTIONS_PATH = ".github/git-commit-instructions.md" as const;
+const commitInstructionsPath = ".github/git-commit-instructions.md" as const;
 
 /**
  * プロジェクト固有のコミットメッセージガイドラインを読み込みます。
@@ -16,7 +16,7 @@ export const readCommitInstructions: Effect.Effect<
   FileSystem.FileSystem
 > = Effect.gen(function* () {
   const fs = yield* FileSystem.FileSystem;
-  return yield* fs.readFileString(COMMIT_INSTRUCTIONS_PATH, "utf8").pipe(
+  return yield* fs.readFileString(commitInstructionsPath, "utf8").pipe(
     Effect.map(Option.some),
     Effect.catchTag("SystemError", (err) =>
       err.reason === "NotFound" ? Effect.succeed(Option.none<string>()) : Effect.fail(err),

--- a/plugins/kyosei/src/conversation.ts
+++ b/plugins/kyosei/src/conversation.ts
@@ -144,7 +144,7 @@ interface GraphQLConnectionPageResponse<TNode> {
 
 // --- GraphQLクエリ ---
 
-const COMMENT_FIELDS = `
+const commentFields = `
   id
   author { login }
   body
@@ -153,7 +153,7 @@ const COMMENT_FIELDS = `
   url
 `;
 
-const REVIEW_FIELDS = `
+const reviewFields = `
   id
   author { login }
   state
@@ -162,7 +162,7 @@ const REVIEW_FIELDS = `
   url
 `;
 
-const REVIEW_THREAD_FIELDS = `
+const reviewThreadFields = `
   id
   isResolved
   isOutdated
@@ -174,12 +174,12 @@ const REVIEW_THREAD_FIELDS = `
   comments(first: 100) {
     pageInfo { hasNextPage endCursor }
     nodes {
-      ${COMMENT_FIELDS}
+      ${commentFields}
     }
   }
 `;
 
-const INITIAL_QUERY = `
+const initialQuery = `
   query($owner: String!, $repo: String!, $number: Int!) {
     repository(owner: $owner, name: $repo) {
       pullRequest(number: $number) {
@@ -189,15 +189,15 @@ const INITIAL_QUERY = `
         url
         comments(first: 100) {
           pageInfo { hasNextPage endCursor }
-          nodes { ${COMMENT_FIELDS} }
+          nodes { ${commentFields} }
         }
         reviews(first: 100) {
           pageInfo { hasNextPage endCursor }
-          nodes { ${REVIEW_FIELDS} }
+          nodes { ${reviewFields} }
         }
         reviewThreads(first: 100) {
           pageInfo { hasNextPage endCursor }
-          nodes { ${REVIEW_THREAD_FIELDS} }
+          nodes { ${reviewThreadFields} }
         }
       }
     }
@@ -219,13 +219,13 @@ function buildPageQuery(connectionName: string, nodeFields: string): string {
 `;
 }
 
-const THREAD_COMMENTS_PAGE_QUERY = `
+const threadCommentsPageQuery = `
   query($threadId: ID!, $after: String) {
     node(id: $threadId) {
       ... on PullRequestReviewThread {
         comments(first: 100, after: $after) {
           pageInfo { hasNextPage endCursor }
-          nodes { ${COMMENT_FIELDS} }
+          nodes { ${commentFields} }
         }
       }
     }
@@ -254,7 +254,7 @@ function getAllThreadComments(
     let { hasNextPage, endCursor } = thread.comments.pageInfo;
     while (hasNextPage) {
       const page = yield* Effect.tryPromise(() =>
-        octokit.graphql<GraphQLThreadCommentsPageResponse>(THREAD_COMMENTS_PAGE_QUERY, {
+        octokit.graphql<GraphQLThreadCommentsPageResponse>(threadCommentsPageQuery, {
           threadId: thread.id,
           after: endCursor,
         }),
@@ -330,7 +330,7 @@ export function getConversation(
 
     // 初回クエリで3つのconnectionを同時に取得します。
     const initial = yield* Effect.tryPromise(() =>
-      octokit.graphql<GraphQLInitialResponse>(INITIAL_QUERY, variables),
+      octokit.graphql<GraphQLInitialResponse>(initialQuery, variables),
     );
     const pr = initial.repository.pullRequest;
 
@@ -345,7 +345,7 @@ export function getConversation(
           octokit,
           variables,
           "comments",
-          COMMENT_FIELDS,
+          commentFields,
           pr.comments.pageInfo,
           commentNodes,
         ),
@@ -353,7 +353,7 @@ export function getConversation(
           octokit,
           variables,
           "reviews",
-          REVIEW_FIELDS,
+          reviewFields,
           pr.reviews.pageInfo,
           reviewNodes,
         ),
@@ -361,7 +361,7 @@ export function getConversation(
           octokit,
           variables,
           "reviewThreads",
-          REVIEW_THREAD_FIELDS,
+          reviewThreadFields,
           pr.reviewThreads.pageInfo,
           reviewThreadNodes,
         ),

--- a/plugins/pr/src/read-contributing.ts
+++ b/plugins/pr/src/read-contributing.ts
@@ -7,12 +7,12 @@ import { findCaseInsensitive, readIfExists } from "./read-if-exists";
  * `CONTRIBUTING`ガイドラインの検索場所。
  * GitHubの表示優先度の順に並べ、最初に見つかったものを採用します。
  */
-const CONTRIBUTING_LOCATIONS = [".github", ".", "docs"] as const;
+const contributingLocations = [".github", ".", "docs"] as const;
 
 /**
  * 正規のファイル名。大文字小文字のバリエーションは実行時に吸収します。
  */
-const CONTRIBUTING_NAME = "CONTRIBUTING.md" as const;
+const contributingName = "CONTRIBUTING.md" as const;
 
 export interface ContributingFile {
   readonly path: string;
@@ -30,7 +30,7 @@ function readAtLocation(
   return Effect.gen(function* () {
     const path = yield* Path.Path;
     const dir = path.join(root, location);
-    const found = yield* findCaseInsensitive(dir, CONTRIBUTING_NAME);
+    const found = yield* findCaseInsensitive(dir, contributingName);
     if (Option.isNone(found)) {
       return Option.none<ContributingFile>();
     }
@@ -54,7 +54,7 @@ export function readContributing(
 > {
   return Effect.gen(function* () {
     const candidates = yield* Effect.all(
-      CONTRIBUTING_LOCATIONS.map((location) => readAtLocation(root, location)),
+      contributingLocations.map((location) => readAtLocation(root, location)),
       { concurrency: "unbounded" },
     );
     return Option.fromNullable(candidates.find(Option.isSome)).pipe(Option.flatten);

--- a/plugins/pr/src/read-pull-request-template.ts
+++ b/plugins/pr/src/read-pull-request-template.ts
@@ -7,17 +7,17 @@ import { findCaseInsensitive, readIfExists, readdirIfExists } from "./read-if-ex
  * pull requestテンプレートの検索場所。
  * GitHubの表示優先度の順に並べ、全マッチを返します。
  */
-const TEMPLATE_LOCATIONS = [".github", "docs", "."] as const;
+const templateLocations = [".github", "docs", "."] as const;
 
 /**
  * 単一ファイル形式の正規ファイル名。大文字小文字のバリエーションは実行時に吸収します。
  */
-const TEMPLATE_FILE_NAME = "pull_request_template.md" as const;
+const templateFileName = "pull_request_template.md" as const;
 
 /**
  * 複数テンプレート形式の正規ディレクトリ名。大文字小文字のバリエーションは実行時に吸収します。
  */
-const TEMPLATE_DIR_NAME = "PULL_REQUEST_TEMPLATE" as const;
+const templateDirName = "PULL_REQUEST_TEMPLATE" as const;
 
 export interface PullRequestTemplate {
   readonly path: string;
@@ -35,7 +35,7 @@ function readSingleAtLocation(
   return Effect.gen(function* () {
     const path = yield* Path.Path;
     const dir = path.join(root, location);
-    const found = yield* findCaseInsensitive(dir, TEMPLATE_FILE_NAME);
+    const found = yield* findCaseInsensitive(dir, templateFileName);
     if (Option.isNone(found)) {
       return Option.none<PullRequestTemplate>();
     }
@@ -52,7 +52,7 @@ function readMultiAtLocation(
   return Effect.gen(function* () {
     const path = yield* Path.Path;
     const dir = path.join(root, location);
-    const found = yield* findCaseInsensitive(dir, TEMPLATE_DIR_NAME);
+    const found = yield* findCaseInsensitive(dir, templateDirName);
     if (Option.isNone(found)) {
       return [] as readonly PullRequestTemplate[];
     }
@@ -93,11 +93,11 @@ export function readPullRequestTemplates(
     const [singleResults, multiResults] = yield* Effect.all(
       [
         Effect.all(
-          TEMPLATE_LOCATIONS.map((location) => readSingleAtLocation(root, location)),
+          templateLocations.map((location) => readSingleAtLocation(root, location)),
           { concurrency: "unbounded" },
         ),
         Effect.all(
-          TEMPLATE_LOCATIONS.map((location) => readMultiAtLocation(root, location)),
+          templateLocations.map((location) => readMultiAtLocation(root, location)),
           { concurrency: "unbounded" },
         ),
       ],


### PR DESCRIPTION
TypeScriptでは定数に見えようが`camelCase`にするべき。
`UPPER_SNAKE_CASE`はなるべく避けるべきだと考えています。
Rustではまた別の命名規則があるため、
そちらは問題にしていません。
