### PR TITLE
refactor: 各設定JSONにSchemaStoreの`$schema`を追加

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
   "name": "konoka",
   "owner": {
     "name": "ncaq",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "extraKnownMarketplaces": {
     "konoka": {
       "source": {

--- a/plugins/commit/.claude-plugin/plugin.json
+++ b/plugins/commit/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "commit",
   "version": "2.7.4",
   "description": "Generate a commit message from staged changes and let the user review before committing. Use when the user wants to commit changes or create a git commit.",

--- a/plugins/haskell-tasuke/.claude-plugin/plugin.json
+++ b/plugins/haskell-tasuke/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "haskell-tasuke",
   "version": "1.0.0",
   "description": "Haskell prompt for AI coding assistants.",

--- a/plugins/kyosei/.claude-plugin/plugin.json
+++ b/plugins/kyosei/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "kyosei",
   "version": "3.4.3",
   "description": "Code review for PRs or local changes. Covers code quality, dependency updates, performance, test coverage, documentation accuracy, and security.",

--- a/plugins/log-analyzer/.claude-plugin/plugin.json
+++ b/plugins/log-analyzer/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "log-analyzer",
   "version": "1.0.0",
   "description": "Extract key information from verbose command output while keeping main conversation context lean.",

--- a/plugins/nix-tasuke/.claude-plugin/plugin.json
+++ b/plugins/nix-tasuke/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "nix-tasuke",
   "version": "1.0.0",
   "description": "Nix best practices, command patterns, and more guidance for AI coding assistants.",

--- a/plugins/pr/.claude-plugin/plugin.json
+++ b/plugins/pr/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "pr",
   "version": "1.1.3",
   "description": "Create a GitHub pull request from the current branch.",

--- a/plugins/programming-tasuke/.claude-plugin/plugin.json
+++ b/plugins/programming-tasuke/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "programming-tasuke",
   "version": "2.0.0",
   "description": "General-purpose programming guidance for AI coding assistants.",

--- a/plugins/proofreading-ja/.claude-plugin/plugin.json
+++ b/plugins/proofreading-ja/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "proofreading-ja",
   "version": "1.0.0",
   "description": "Fix typos, grammar, readability, and notation consistency in Japanese text. Use when the user wants to proofread or edit Japanese text.",

--- a/plugins/research/.claude-plugin/plugin.json
+++ b/plugins/research/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "research",
   "version": "1.1.4",
   "description": "Research for information by fast agent.",

--- a/plugins/rm-to-trash/.claude-plugin/plugin.json
+++ b/plugins/rm-to-trash/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "rm-to-trash",
   "version": "1.1.0",
   "description": "Rewrites `rm` (including trash-cli-compatible flags) to `trash` in Bash commands via PreToolUse hook.",

--- a/plugins/web-tasuke/.claude-plugin/plugin.json
+++ b/plugins/web-tasuke/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "web-tasuke",
   "version": "3.1.0",
   "description": "Web development best practices, patterns, and guidance for AI coding assistants.",


### PR DESCRIPTION
`plugin.json`と`marketplace.json`はSchemaStoreに公式スキーマが登録されており、
`settings.json`にも対応するスキーマがあります。
これらに`$schema`を明示しておくと、
catalog非対応のエディタでも補完と検証が確実に効き、
編集時に不正なフィールドや値へ気付けるようになります。

`$schema`は読み込み時に無視される正式なフィールドで、
現行のClaude Codeなら`claude plugin validate`も受理するため、
追記してもプラグインの挙動には影響しません。

対象はSchemaStoreにスキーマが存在する以下に限定しました。

- `plugins/*/.claude-plugin/plugin.json`: claude-code-plugin-manifest
- `.claude-plugin/marketplace.json`: claude-code-marketplace
- `.claude/settings.json`: claude-code-settings

`hooks.json`や`.mcp.json`はSchemaStoreに該当スキーマがないため対象外です。
