### PR TITLE
fix: プラグイン間の依存をdependenciesに宣言

### DIFF
--- a/plugins/kyosei/.claude-plugin/plugin.json
+++ b/plugins/kyosei/.claude-plugin/plugin.json
@@ -1,8 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "kyosei",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "Code review for PRs or local changes. Covers code quality, dependency updates, performance, test coverage, documentation accuracy, and security.",
+  "dependencies": ["research"],
   "author": {
     "name": "ncaq",
     "email": "ncaq@ncaq.net",

--- a/plugins/pr/.claude-plugin/plugin.json
+++ b/plugins/pr/.claude-plugin/plugin.json
@@ -1,8 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "pr",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Create a GitHub pull request from the current branch.",
+  "dependencies": ["commit"],
   "author": {
     "name": "ncaq",
     "email": "ncaq@ncaq.net",

--- a/plugins/programming-tasuke/.claude-plugin/plugin.json
+++ b/plugins/programming-tasuke/.claude-plugin/plugin.json
@@ -1,8 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "programming-tasuke",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "General-purpose programming guidance for AI coding assistants.",
+  "dependencies": ["commit"],
   "author": {
     "name": "ncaq",
     "email": "ncaq@ncaq.net",


### PR DESCRIPTION
他プラグインの機能を前提とするプラグインは、
依存先が無効だとその機能が動かない状態でした。
Claude Codeのプラグイン依存機能を使い、
`plugin.json`の`dependencies`に依存先を宣言します。
これにより各プラグインのインストール時に依存先が自動で導入され、
前提とする機能が確実に利用できるようになります。

宣言した依存は以下です。

- `kyosei`は`research`に依存します。
  `dependency-reviewer`エージェントが`Skill(research)`で横断調査を行うためです。
- `programming-tasuke`は`commit`に依存します。
  `command`スキルがコミットを`commit:commit`と`commit:commit-style`へ委ねるよう指示するためです。
- `pr`は`commit`に依存します。
  `pr-style`スキルがタイトルのスタイルを`commit-style`スキルのガイドラインに従わせるためです。

close #253
