### PR TITLE
fix(research): surveyエージェントのtools定義を明示的に列挙

### DIFF
--- a/plugins/research/.claude-plugin/plugin.json
+++ b/plugins/research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "research",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Research for information by fast agent.",
   "dependencies": ["nix-tasuke"],
   "author": {

--- a/plugins/research/agents/survey.md
+++ b/plugins/research/agents/survey.md
@@ -18,15 +18,53 @@ tools:
   - mcp__backlog__get_pull_requests
   - mcp__backlog__get_wiki
   - mcp__backlog__get_wiki_pages
+  - mcp__github__get_code_scanning_alert
+  - mcp__github__get_commit
+  - mcp__github__get_dependabot_alert
+  - mcp__github__get_discussion
+  - mcp__github__get_discussion_comments
   - mcp__github__get_file_contents
+  - mcp__github__get_issue
+  - mcp__github__get_issue_comments
+  - mcp__github__get_job_logs
+  - mcp__github__get_label
+  - mcp__github__get_latest_release
+  - mcp__github__get_me
+  - mcp__github__get_pull_request
+  - mcp__github__get_pull_request_diff
+  - mcp__github__get_pull_request_files
+  - mcp__github__get_pull_request_review_comments
+  - mcp__github__get_pull_request_reviews
+  - mcp__github__get_pull_request_status
+  - mcp__github__get_release_by_tag
+  - mcp__github__get_secret_scanning_alert
+  - mcp__github__get_tag
+  - mcp__github__get_team_members
+  - mcp__github__get_teams
+  - mcp__github__get_workflow_run
   - mcp__github__issue_read
+  - mcp__github__list_branches
+  - mcp__github__list_code_scanning_alerts
+  - mcp__github__list_commits
+  - mcp__github__list_dependabot_alerts
+  - mcp__github__list_discussion_categories
+  - mcp__github__list_discussions
+  - mcp__github__list_issue_types
   - mcp__github__list_issues
   - mcp__github__list_pull_requests
+  - mcp__github__list_releases
+  - mcp__github__list_secret_scanning_alerts
+  - mcp__github__list_sub_issues
+  - mcp__github__list_tags
+  - mcp__github__list_workflow_jobs
+  - mcp__github__list_workflow_runs
+  - mcp__github__list_workflows
   - mcp__github__pull_request_read
   - mcp__github__search_code
   - mcp__github__search_issues
   - mcp__github__search_pull_requests
   - mcp__github__search_repositories
+  - mcp__github__search_users
   - mcp__plugin_nix-tasuke_nixos__darwin_info
   - mcp__plugin_nix-tasuke_nixos__darwin_list_options
   - mcp__plugin_nix-tasuke_nixos__darwin_options_by_prefix

--- a/plugins/research/agents/survey.md
+++ b/plugins/research/agents/survey.md
@@ -27,12 +27,37 @@ tools:
   - mcp__github__search_issues
   - mcp__github__search_pull_requests
   - mcp__github__search_repositories
-  - mcp__plugin_nix-tasuke_nixos
-  - mcp__plugin_research_cloudflare
-  - mcp__plugin_research_context7
-  - mcp__plugin_research_deepwiki
-  - mcp__plugin_research_mdn
-  - mcp__plugin_research_microsoft-learn
+  - mcp__plugin_nix-tasuke_nixos__darwin_info
+  - mcp__plugin_nix-tasuke_nixos__darwin_list_options
+  - mcp__plugin_nix-tasuke_nixos__darwin_options_by_prefix
+  - mcp__plugin_nix-tasuke_nixos__darwin_search
+  - mcp__plugin_nix-tasuke_nixos__darwin_stats
+  - mcp__plugin_nix-tasuke_nixos__home_manager_info
+  - mcp__plugin_nix-tasuke_nixos__home_manager_list_options
+  - mcp__plugin_nix-tasuke_nixos__home_manager_options_by_prefix
+  - mcp__plugin_nix-tasuke_nixos__home_manager_search
+  - mcp__plugin_nix-tasuke_nixos__home_manager_stats
+  - mcp__plugin_nix-tasuke_nixos__nixhub_find_version
+  - mcp__plugin_nix-tasuke_nixos__nixhub_package_versions
+  - mcp__plugin_nix-tasuke_nixos__nixos_channels
+  - mcp__plugin_nix-tasuke_nixos__nixos_flakes_search
+  - mcp__plugin_nix-tasuke_nixos__nixos_flakes_stats
+  - mcp__plugin_nix-tasuke_nixos__nixos_info
+  - mcp__plugin_nix-tasuke_nixos__nixos_search
+  - mcp__plugin_nix-tasuke_nixos__nixos_stats
+  - mcp__plugin_research_cloudflare__migrate_pages_to_workers_guide
+  - mcp__plugin_research_cloudflare__search_cloudflare_documentation
+  - mcp__plugin_research_context7__query-docs
+  - mcp__plugin_research_context7__resolve-library-id
+  - mcp__plugin_research_deepwiki__ask_question
+  - mcp__plugin_research_deepwiki__read_wiki_contents
+  - mcp__plugin_research_deepwiki__read_wiki_structure
+  - mcp__plugin_research_mdn__get-compat
+  - mcp__plugin_research_mdn__get-doc
+  - mcp__plugin_research_mdn__search
+  - mcp__plugin_research_microsoft-learn__microsoft_code_sample_search
+  - mcp__plugin_research_microsoft-learn__microsoft_docs_fetch
+  - mcp__plugin_research_microsoft-learn__microsoft_docs_search
 model: sonnet
 ---
 


### PR DESCRIPTION
`survey`エージェントの`tools`ではこれまで、
MCPサーバ単位のワイルドカード指定(例: `mcp__plugin_research_cloudflare`)で、
配下の全ツールをまとめて許可していました。
しかし関連ツールの一部にはこのワイルドカード形式を受け付けないものがあるようで、
警告が出ていました。

そこで`nix-tasuke`の`nixos`と、
`research`同梱の`cloudflare`、
`context7`、
`deepwiki`、
`mdn`、
`microsoft-learn`の各MCPについて、
個別のツール名を全て明示的に列挙する形に書き換えました。

あわせて、
GitHub MCPのツール定義側でも従来は明示列挙の方針を取っていたにも関わらず、
読み取り専用のうち`get_commit`、
`get_issue`、
`list_commits`、
`get_pull_request`、
discussion関連、
workflow関連、
release/tag一覧などが抜けていたため追加しました。
情報源としてのGitHubを十分に使えるようにする目的です。

警告の解消と取り回しの改善というユーザにとっての修正なので、
パッチバージョンを上げます。
