### PR TITLE
feat(research): `claude-code-guide`エージェントを情報ソースに追加

### DIFF
--- a/plugins/research/.claude-plugin/plugin.json
+++ b/plugins/research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "research",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Research for information by fast agent.",
   "dependencies": ["nix-tasuke"],
   "author": {

--- a/plugins/research/README.md
+++ b/plugins/research/README.md
@@ -39,9 +39,12 @@ Claude Codeで以下を実行します。
 技術調査や情報収集が必要な場面でClaude Codeが自動的にresearchスキルを起動します。
 
 クエリは自動的に独立したサブクエリに分解され、
-`survey`エージェントが並列起動して調査を行います。
+適切なエージェントが並列起動して調査を行います。
 
-`survey`エージェントはコスト節約のためと速度のために`sonnet`で動作します。
+- `survey`エージェントが常に調査を実行します。
+  コスト節約と速度のため`sonnet`で動作します。
+- Claude Code、Claude Agent SDK、Claude APIに関するサブクエリは、
+  Claude Code組み込みの`claude-code-guide`エージェントも使います。
 
 例えばVitestとJestの比較であれば、
 それぞれが別のサブクエリとして並列に調査されます。
@@ -56,11 +59,15 @@ Claude Codeで以下を実行します。
 
 ### 常時利用可能
 
-| ソース           | 内容             |
-| ---------------- | ---------------- |
-| Web検索          | 一般的なWeb検索  |
-| WebFetch         | 任意のURL取得    |
-| ローカルファイル | Glob、Grep、Read |
+| ソース            | 内容                                            |
+| ----------------- | ----------------------------------------------- |
+| Web検索           | 一般的なWeb検索                                 |
+| WebFetch          | 任意のURL取得                                   |
+| ローカルファイル  | Glob、Grep、Read                                |
+| claude-code-guide | Claude Code、Claude Agent SDK、Claude APIの情報 |
+
+`claude-code-guide`はClaude Code組み込みのエージェントです。
+プラグインのインストールは不要です。
 
 ### このプラグインが提供
 

--- a/plugins/research/skills/research/SKILL.md
+++ b/plugins/research/skills/research/SKILL.md
@@ -2,7 +2,7 @@
 name: research
 description: Investigate any topic by querying multiple external sources (web, official docs, GitHub, MCP servers). Use whenever a question requires information not already in the working context, including library behavior, API specifications, error diagnostics, version comparisons, or general factual lookup.
 argument-hint: "query"
-allowed-tools: Agent(research:survey)
+allowed-tools: Agent(claude-code-guide), Agent(research:survey)
 ---
 
 # クエリの分解
@@ -10,7 +10,7 @@ allowed-tools: Agent(research:survey)
 `$ARGUMENTS`を分析し、
 独立して調査可能なサブクエリに分解してください。
 
-分解の方針:
+## 分解の方針
 
 - 比較調査(AとBの比較)は対象ごとに分ける
 - 複数の技術トピックが含まれる場合はトピックごとに分ける
@@ -20,9 +20,38 @@ allowed-tools: Agent(research:survey)
   - コミュニティの評判
 - 分解できない単一の質問はそのまま1つのサブクエリとする
 
+# エージェント選択の指針
+
+## `survey`エージェント
+
+常に利用してください。
+
+他のエージェントを利用する場合も、
+`survey`エージェントも併用して調査してください。
+
+## `claude-code-guide`エージェント
+
+以下のトピックに該当する場合は利用してください。
+
+- Claude Code
+  - CLIツール
+  - フック
+  - スラッシュコマンド
+  - MCPサーバ
+  - 設定
+  - IDE連携
+  - キーボードショートカット
+- Claude Agent SDK
+  - カスタムエージェントの構築
+- Claude API
+  - ツール利用
+  - Anthropic API
+  - Anthropic SDK
+
 # 並列調査
 
-分解した各サブクエリに対して`survey`エージェントを並列で起動してください。
+分解した各サブクエリに対して、
+適切なエージェントを並列で起動してください。
 全てのエージェントを同時に起動することが重要です。
 
 各エージェントには、


### PR DESCRIPTION
`/research`スキルが調査時に`claude-code-guide`エージェントも並列で起動できるようにしました。

- Claude Code
- Claude Agent SDK
- Claude API

に関するサブクエリは、
従来の`survey`エージェントに加えて、
Claude Code組み込みの`claude-code-guide`エージェントへも振り分けます。

`survey`エージェントは汎用Web情報に強いですが、
Claude Code本体の機能やAnthropic SDKに関する仕様は、
`claude-code-guide`エージェントの方が踏み込んで回答できるためです。
`claude-code-guide`はClaude Code組み込みのため、
追加のプラグインインストールは不要で常に利用できます。

ユーザにとって新しい情報ソースが追加されるため、
マイナーバージョンを上げます。

close #314
