### PR TITLE
feat(commit): `effort: medium`を設定して過剰な思考を抑制

### DIFF
--- a/plugins/commit/.claude-plugin/plugin.json
+++ b/plugins/commit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "commit",
-  "version": "2.7.6",
+  "version": "2.8.0",
   "description": "Generate a commit message from staged changes and let the user review before committing. Use when the user wants to commit changes or create a git commit.",
   "author": {
     "name": "ncaq",

--- a/plugins/commit/skills/commit-style/SKILL.md
+++ b/plugins/commit/skills/commit-style/SKILL.md
@@ -3,6 +3,7 @@ name: commit-style
 description: Commit message style guidelines. Use when writing or proposing git commit messages, including direct git commit commands outside the /commit skill.
 allowed-tools: Bash(git log:*), Bash(read-commit-instructions:*)
 user-invocable: false
+effort: medium
 ---
 
 コミットメッセージを書く際のスタイルガイドラインです。

--- a/plugins/commit/skills/commit/SKILL.md
+++ b/plugins/commit/skills/commit/SKILL.md
@@ -2,6 +2,7 @@
 name: commit
 description: Generate a commit message from staged changes and let the user review before committing. Use when the user wants to commit changes or create a git commit.
 allowed-tools: AskUserQuestion, Bash(commit-prepare:*), Bash(git commit:*), Bash(konoka-commit-editor:*), Edit, Read, Write, Skill(commit-style)
+effort: medium
 ---
 
 Gitリポジトリの変更をコミットします。


### PR DESCRIPTION
`commit`スキルと`commit-style`スキルのフロントマターに、
`effort: medium`を追加しました。

これまでデフォルトのeffortが継承されていたため、
コミットメッセージ生成の場面で必要以上に思考が長引くことがありました。
コミットメッセージの生成は定型的な作業が多く、
セッション全体のeffortほどの推論は不要なため、
`medium`に固定して所要時間を抑えます。

`effort`フィールドは`SKILL.md`のフロントマターで直接指定でき、
`context: fork`なしでもスキルアクティブ中の`reasoning_effort`に反映されます。
セッションモデル自体は変わらず、
thinkingバジェットだけが`medium`相当に切り替わります。

ユーザにとって体感的な挙動が変わる機能追加のため、
マイナーバージョンを上げて`2.8.0`としました。

close #310
