### PR TITLE
feat: スキルとエージェントに`effort: medium`を設定

### DIFF
--- a/plugins/haskell-tasuke/.claude-plugin/plugin.json
+++ b/plugins/haskell-tasuke/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "haskell-tasuke",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Haskell prompt for AI coding assistants.",
   "author": {
     "name": "ncaq",

--- a/plugins/haskell-tasuke/skills/bump-cabal-index-state/SKILL.md
+++ b/plugins/haskell-tasuke/skills/bump-cabal-index-state/SKILL.md
@@ -2,6 +2,7 @@
 name: bump-cabal-index-state
 description: Update Cabal project index-state to the latest timestamp. Use when it needs to bump the cabal index-state.
 allowed-tools: Bash(cabal build:*), Bash(cabal update:*), Bash(gh pr create:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(git status:*), Bash(git switch:*), Bash(nix flake check:*), Edit, Glob, Grep, Read, Write
+effort: medium
 ---
 
 cabalプロジェクトの`index-state`を最新に更新します。

--- a/plugins/kyosei/.claude-plugin/plugin.json
+++ b/plugins/kyosei/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "kyosei",
-  "version": "3.4.5",
+  "version": "3.5.0",
   "description": "Code review for PRs or local changes. Covers code quality, dependency updates, performance, test coverage, documentation accuracy, and security.",
   "dependencies": ["research"],
   "author": {

--- a/plugins/kyosei/skills/kyosei/SKILL.md
+++ b/plugins/kyosei/skills/kyosei/SKILL.md
@@ -3,6 +3,7 @@ name: kyosei
 description: Code review for PRs or local changes. Covers code quality, dependency updates, performance, test coverage, documentation accuracy, and security. Use when reviewing PRs, checking code quality, or running comprehensive code reviews.
 argument-hint: "[pr-url]"
 allowed-tools: Bash(node:*), Glob, Grep, Read, Task, mcp__github
+effort: medium
 ---
 
 # get-review-infoでの情報の取得

--- a/plugins/pr/.claude-plugin/plugin.json
+++ b/plugins/pr/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "pr",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "Create a GitHub pull request from the current branch.",
   "dependencies": ["commit"],
   "author": {

--- a/plugins/pr/skills/pr-style/SKILL.md
+++ b/plugins/pr/skills/pr-style/SKILL.md
@@ -3,6 +3,7 @@ name: pr-style
 description: Pull request style guidelines covering title, body, assignee, and label selection. Use when writing or proposing GitHub pull requests, including direct `gh pr create` invocations outside the /pr skill.
 allowed-tools: Bash(gh label list:*), Bash(gh pr list:*), Bash(gh pr view:*), Bash(gh repo view:*), Bash(git diff:*), Bash(git log:*), Bash(read-contributing:*), Bash(read-pull-request-template:*), mcp__github__get_me, mcp__github__list_pull_requests, mcp__github__pull_request_read
 user-invocable: false
+effort: medium
 ---
 
 GitHubのpull requestを作成するときのスタイルガイドラインです。

--- a/plugins/pr/skills/pr/SKILL.md
+++ b/plugins/pr/skills/pr/SKILL.md
@@ -2,6 +2,7 @@
 name: pr
 description: Generate a GitHub pull request title and body from the current branch and let the user review before creation. Use when the user wants to create a pull request.
 allowed-tools: AskUserQuestion, Bash(git status:*), Bash(konoka-pr-editor:*), Bash(prepare-editmsg:*), Bash(sync-and-push:*), Edit, Read, Skill(pr-style), Write, mcp__github__create_pull_request, mcp__github__issue_write
+effort: medium
 ---
 
 GitHubのpull requestを作成します。

--- a/plugins/research/.claude-plugin/plugin.json
+++ b/plugins/research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "research",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Research for information by fast agent.",
   "dependencies": ["nix-tasuke"],
   "author": {

--- a/plugins/research/agents/survey.md
+++ b/plugins/research/agents/survey.md
@@ -97,6 +97,7 @@ tools:
   - mcp__plugin_research_microsoft-learn__microsoft_docs_fetch
   - mcp__plugin_research_microsoft-learn__microsoft_docs_search
 model: sonnet
+effort: medium
 ---
 
 あらゆる情報ソースを横断検索して回答します。


### PR DESCRIPTION
以下のスキルとエージェントのフロントマターに、
`effort: medium`を追加しました。

- `pr`プラグインの`pr`スキルと`pr-style`スキル
- `kyosei`プラグインの`kyosei`スキル
- `haskell-tasuke`プラグインの`bump-cabal-index-state`スキル
- `research`プラグインの`survey`エージェント

これまでデフォルトのeffortを継承していましたが、
いずれも作業手順が定型的、
あるいはオーケストレーションが中心で、
セッション全体のeffortほどの推論は不要なためです。

`pr`系はPR本文生成という定型作業、
`kyosei`は並列サブエージェントへの振り分け、
`bump-cabal-index-state`はcabalコマンドの実行とファイル書き換えの決まった流れ、
`survey`は情報源を横断して結果を要約するという中身が主です。

なお`haskell-tasuke`の他スキルや`web-tasuke`などの知識スキルには、
`effort`を設定していません。
知識スキルがマッチしてロードされたターンでは、
ガイドラインを参照しながらコードを書くメインエージェントの処理全体に、
`effort`が波及してしまうためです。
意図しない品質低下を避けるためそれらは据え置きとしました。

ユーザにとって体感的な挙動が変わる機能追加のため、
各プラグインのマイナーバージョンを上げました。

- `pr`: 1.1.5 → 1.2.0
- `kyosei`: 3.4.5 → 3.5.0
- `haskell-tasuke`: 1.1.0 → 1.2.0
- `research`: 1.3.0 → 1.4.0
