### PR TITLE
feat(web-tasuke): TypeScriptのベストプラクティススキルを追加

### DIFF
--- a/plugins/web-tasuke/.claude-plugin/plugin.json
+++ b/plugins/web-tasuke/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "web-tasuke",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Web development best practices, patterns, and guidance for AI coding assistants.",
   "author": {
     "name": "ncaq",

--- a/plugins/web-tasuke/skills/avoid-for/SKILL.md
+++ b/plugins/web-tasuke/skills/avoid-for/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: avoid-for
+description: Avoid for loops (C-style, for...of, for...in) in TypeScript/JavaScript. Prefer higher-order Array methods like map, filter, find, some, every, reduce. Use when writing or reviewing loops or iteration over arrays, objects, Map, Set, or String.
+user-invocable: false
+---
+
+# `for`文をなるべく避ける
+
+`for`文は強力すぎて、
+コードの意図が読み取りにくくなります。
+構造化プログラミングにおいて`goto`相当の機能を避けるのと同じ理由で、
+`for`文もなるべく避けてください。
+
+避ける対象は以下の全てです。
+
+- C言語方式の`for (let i = 0; i < n; i++)`
+- `for...of`
+- `for...in`
+
+forではありませんが、
+同じくループ構文の以下も避けてください。
+
+- `while`
+- `do...while`
+
+## なぜ避けるのか
+
+`for`文は何でもできてしまいます。
+
+- 要素の変換
+- 絞り込み
+- 集計
+- 検索
+- 副作用の実行
+
+どの操作をしているのかはループ本体を注意深く読まないと分かりません。
+
+`map`や`filter`のような高抽象度の関数は、
+名前を見ただけで「変換している」「絞り込んでいる」と意図が伝わります。
+`goto`が制御フローを自由にしすぎて構造化プログラミングで避けられたのと同じく、
+`for`はデータの流れを自由にしすぎます。
+より弱く意図の限定された関数に置き換えることで、
+読み手の負担が減ります。
+
+## Arrayの場合
+
+Arrayのメソッドでやりたいことに対応するものを選びます。
+
+| やりたいこと               | `for`の代替                  |
+| -------------------------- | ---------------------------- |
+| 各要素を変換する           | `map`                        |
+| 変換して一段平坦化する     | `flatMap`                    |
+| 条件で絞り込む             | `filter`                     |
+| 最初の一致を探す           | `find` / `findIndex`         |
+| 最後の一致を探す           | `findLast` / `findLastIndex` |
+| 含まれるか調べる           | `includes`                   |
+| 位置を調べる               | `indexOf` / `lastIndexOf`    |
+| 一つでも満たすか調べる     | `some`                       |
+| すべて満たすか調べる       | `every`                      |
+| 単一の値に集計する         | `reduce` / `reduceRight`     |
+| 副作用だけ実行する         | `forEach`                    |
+| ネストした配列を平坦化する | `flat`                       |
+| 文字列に連結する           | `join`                       |
+| 並べ替える                 | `toSorted`                   |
+| 逆順にする                 | `toReversed`                 |
+
+変換と絞り込みはチェーンで素直に書けます。
+
+```typescript
+// 避ける
+const result = [];
+for (let i = 0; i < users.length; i++) {
+  if (users[i].active) {
+    result.push(users[i].name);
+  }
+}
+
+// 良い
+const result = users.filter((user) => user.active).map((user) => user.name);
+```
+
+### 大域脱出が必要な場合
+
+途中で打ち切りたい(`break`相当の)場合は、
+専用のメソッドで表現できます。
+
+- 一つでも条件を満たすか: `some`
+- すべて満たすか: `every`
+- 最初の一致を取得: `find`
+
+```typescript
+// 避ける
+let found = false;
+for (const user of users) {
+  if (user.id === targetId) {
+    found = true;
+    break;
+  }
+}
+
+// 良い
+const found = users.some((user) => user.id === targetId);
+```
+
+`some`と`every`と`find`は、
+返値が確定した時点で反復を打ち切るので、
+性能面でも`break`と同等です。
+
+### `reduce`は控えめに使用
+
+`reduce`は`for`よりは弱いものの、
+それでも強力で読みにくくなりがちです。
+`map`や`filter`や`some`で表現できる処理を`reduce`で書くのは避けてください。
+
+単純な合計のような処理は`reduce`が適していますが、
+複雑な蓄積処理を`reduce`に詰め込むと意図が埋もれます。
+
+## Objectの場合
+
+`for...in`ではなく、
+
+- `Object.keys`
+- `Object.values`
+- `Object.entries`
+
+などで配列に変換してから、
+Arrayのメソッドを使います。
+
+```typescript
+// 避ける
+for (const key in obj) {
+  console.log(key, obj[key]);
+}
+
+// 良い
+Object.entries(obj).forEach(([key, value]) => {
+  console.log(key, value);
+});
+```
+
+変換して新しいオブジェクトを作る場合は、
+`Object.fromEntries`と組み合わせます。
+
+```typescript
+const upper = Object.fromEntries(
+  Object.entries(obj).map(([key, value]) => [key, value.toUpperCase()]),
+);
+```
+
+## MapとSetの場合
+
+`Map`と`Set`の
+
+- `entries`
+- `keys`
+- `values`
+
+などはイテレータを返します。
+イテレータには`map`や`filter`などのイテレータヘルパーが生えているので、
+配列に変換せずそのままチェーンできます。
+最終的に配列が必要な場合だけ`toArray`で配列にします。
+
+```typescript
+// Map
+const names = userMap
+  .values()
+  .map((user) => user.name)
+  .toArray();
+const activeEntries = userMap
+  .entries()
+  .filter(([key, value]) => value.active)
+  .toArray();
+
+// Set
+const doubled = numberSet
+  .values()
+  .map((n) => n * 2)
+  .toArray();
+```
+
+`Map`と`Set`には`forEach`もあるので、
+副作用だけ実行したい場合は直接呼べます。
+
+イテレータヘルパーがサポートされていない環境で実行する場合や、
+イテレータが対応していないメソッドを使いたい場合は、
+スプレッド構文や`Array.from`で配列に変換してからArrayのメソッドを使ってください。
+
+```typescript
+const names = [...userMap.values()].map((user) => user.name);
+```
+
+## Stringの場合
+
+文字列を1文字ずつ`for`で回す代わりに、配列やイテレータの操作に置き換えます。
+
+- 文字ごとに処理する: スプレッド構文`[...str]`や`Array.from`で配列化する
+- 区切りで分割する: `split`
+- すべての一致を取り出す: `matchAll`(イテレータを返す)
+- 置換する: `replaceAll`(コールバックも渡せる)
+
+```typescript
+// 避ける
+let count = 0;
+for (let i = 0; i < str.length; i++) {
+  if (str[i] === "a") count++;
+}
+
+// 良い
+const count = [...str].filter((char) => char === "a").length;
+```
+
+サロゲートペアを含む文字列では、
+`[...str]`はコードポイント単位で分割するため、
+`str[i]`の添字アクセスより安全です。
+
+## 例外
+
+### 高抽象度の関数で素直に書けない場合
+
+高抽象度の関数で素直に書けない場合に限り、
+`for...of`を使ってよいです。
+
+- `await`を直列で実行したい場合(`for await...of`)
+  - `Promise`の操作で問題ない場合は`Promise.all`などを使ってください
+- 複数の配列を同時に進めるなど複雑な制御が必要な場合
+- 早期`return`で関数全体を抜けたい場合
+
+C方式の`for`や`for...in`よりは`for...of`の方がまだ読みやすいので、
+どうしてもループが必要なら`for...of`を選んでください。
+
+`for...in`はプロトタイプチェーン上のプロパティも列挙してしまうため、
+ほぼ常に避けるべきです。
+
+### 性能が格段に違う場合
+
+性能が極めて重要で、
+メソッドチェーンによる中間配列の生成がボトルネックになる場合は、
+`for ... of`を使ってよいです。
+ただし実際に計測して問題だと確認できた場合に限ります。
+多くの場合は可読性を優先してください。
+
+### 既存コードが使っている場合
+
+既存コードに大量の`for`がある場合、
+それらを無理に一度に書き換える必要はありません。
+新しく書くコードで高抽象度の関数を優先し、
+既存の`for`は変更のついでに徐々に置き換えていくのが現実的です。

--- a/plugins/web-tasuke/skills/prefer-specific-method/SKILL.md
+++ b/plugins/web-tasuke/skills/prefer-specific-method/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: prefer-specific-method
+description: Prefer the most specific built-in method over general-purpose ones in TypeScript/JavaScript. Use includes over indexOf, some over filter().length, find over filter()[0], flatMap over map().flat(), at(-1) over length-based access, startsWith/endsWith/includes over indexOf on strings, structuredClone over JSON round-trip. Use when writing or reviewing code that searches, tests, transforms arrays, objects, or strings.
+user-invocable: false
+---
+
+# より特化した関数を優先する
+
+同じ結果が得られる方法が複数ある場合は、
+やりたいことに最も特化した関数を選んでください。
+
+特化した関数は名前そのものが意図を表すので、
+読み手が「この比較は何のためか」を推測せずに済みます。
+汎用的な関数を条件式と組み合わせて目的を表現すると、
+意図が式の形に埋もれて読みにくくなります。
+
+これは[avoid-for](../avoid-for/SKILL.md)で`for`を高抽象度の関数に置き換えるのと同じ発想を、
+関数同士の選択にも広げたものです。
+
+## 存在するかどうかを調べる
+
+要素が含まれるかを知りたいだけなら、
+位置を返す`indexOf`ではなく、
+真偽値を返す`includes`を使います。
+
+```typescript
+// 避ける
+if (items.indexOf(target) !== -1) {
+}
+
+// 良い
+if (items.includes(target)) {
+}
+```
+
+`includes`は意図が明確なだけでなく、
+`NaN`を正しく見つけられるという正確性の利点もあります。
+`indexOf`は厳密等価(`===`)で比較するため`NaN`を見つけられませんが、
+`includes`はSameValueZeroで比較するため`NaN`も見つけられます。
+
+```typescript
+[NaN].indexOf(NaN); // -1 (見つからない)
+[NaN].includes(NaN); // true
+```
+
+## 条件を満たす要素の有無を調べる
+
+絞り込んだ結果の件数を見るのではなく、
+`some`や`every`で真偽を直接求めます。
+
+```typescript
+// 避ける
+if (0 < users.filter((user) => user.active).length) {
+}
+
+// 良い
+if (users.some((user) => user.active)) {
+}
+```
+
+`some`は最初に条件を満たした時点で打ち切るので、
+全件を絞り込む`filter`より無駄がありません。
+「すべてが条件を満たすか」は`every`を使います。
+
+## 条件を満たす最初の要素を取り出す
+
+絞り込んでから先頭を取るのではなく、
+`find`で直接取り出します。
+
+```typescript
+// 避ける
+const found = users.filter((user) => user.id === targetId)[0];
+
+// 良い
+const found = users.find((user) => user.id === targetId);
+```
+
+最後の要素が欲しい場合は`findLast`、
+位置が欲しい場合は`findIndex`や`findLastIndex`を使います。
+
+## 変換してから平坦化する
+
+`map`してから`flat`するのではなく、
+`flatMap`を使います。
+
+```typescript
+// 避ける
+const tags = posts.map((post) => post.tags).flat();
+
+// 良い
+const tags = posts.flatMap((post) => post.tags);
+```
+
+## 末尾や負の位置の要素にアクセスする
+
+`length`を使った添字計算ではなく、
+`at`を使います。
+
+```typescript
+// 避ける
+const last = items[items.length - 1];
+
+// 良い
+const last = items.at(-1);
+```
+
+`at`は文字列にもあります。
+
+## 文字列の前方一致と後方一致を調べる
+
+位置を計算するのではなく、
+専用のメソッドを使います。
+
+```typescript
+// 避ける
+if (path.indexOf("/etc/") === 0) {
+}
+if (name.lastIndexOf("hosts") === name.length - "hosts".length) {
+}
+
+// 良い
+if (path.startsWith("/etc/")) {
+}
+if (name.endsWith("hosts")) {
+}
+```
+
+文字列に部分文字列が含まれるかも、
+`indexOf`ではなく`includes`で調べます。
+
+## 文字列をすべて置換する
+
+グローバルフラグ付きの正規表現ではなく、
+`replaceAll`で意図を示せます。
+
+```typescript
+// 避ける
+const escaped = text.replace(/&/g, "&amp;");
+
+// 良い
+const escaped = text.replaceAll("&", "&amp;");
+```
+
+正規表現が不要な単純な文字列置換では、
+`replaceAll`に文字列を直接渡せます。
+
+## 重複を取り除く
+
+`filter`と`indexOf`を組み合わせるのではなく、
+`Set`を使います。
+
+```typescript
+// 避ける
+const unique = items.filter((item, index) => items.indexOf(item) === index);
+
+// 良い
+const unique = [...new Set(items)];
+```
+
+`Set`を使う方が意図が明確で、
+計算量の面でも有利です。
+
+## オブジェクトをディープコピーする
+
+`JSON`の往復ではなく、
+`structuredClone`を使います。
+
+```typescript
+// 避ける
+const copy = JSON.parse(JSON.stringify(original));
+
+// 良い
+const copy = structuredClone(original);
+```
+
+`JSON`の往復は`undefined`や`Date`や`Map`などを正しく扱えませんが、
+`structuredClone`はこれらに対応します。
+
+## 共通する考え方
+
+汎用的な関数に条件式やフラグを足して目的を表現できると気づいたら、
+その目的そのものを名前に持つ関数がないか確認してください。
+
+- 件数や位置を求めてから比較しているなら、真偽や要素を直接返す関数があることが多い
+- 複数の操作を連結しているなら、それを一度に行う関数があることが多い
+
+特化した関数は意図が明確になるだけでなく、
+途中で打ち切る、
+エッジケースを正しく扱うなど、
+実装上の利点も持つことが多いです。

--- a/plugins/web-tasuke/skills/variable-naming/SKILL.md
+++ b/plugins/web-tasuke/skills/variable-naming/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: variable-naming
+description: Variable naming conventions for TypeScript/JavaScript. Prefer camelCase even for constants and avoid UPPER_SNAKE_CASE. Use when naming or reviewing variables or constants.
+user-invocable: false
+---
+
+# 変数の命名規則 (TypeScript/JavaScript)
+
+TypeScript/JavaScriptのコードにおける変数の命名規則です。
+
+ファイル名やディレクトリ名については[file-naming](../file-naming/SKILL.md)を参照してください。
+
+## 基本のケース
+
+変数・パラメータには基本的にcamelCaseを使います。
+
+```typescript
+const taxedPrice = itemPrice * (1 + taxRate);
+const userName = profile.displayName;
+```
+
+## 定数でもUPPER_SNAKE_CASEは避けてcamelCaseを使う
+
+再代入されない定数のように見える変数でも、
+基本的にはUPPER_SNAKE_CASEではなくcamelCaseを使ってください。
+
+```typescript
+// 良い
+const maxRetryCount = 3;
+const apiBaseUrl = "https://example.com";
+const emailPattern = /^.+@.+$/;
+
+// 避ける
+const MAX_RETRY_COUNT = 3;
+const API_BASE_URL = "https://example.com";
+const EMAIL_PATTERN = /^.+@.+$/;
+```
+
+理由は以下の通りです。
+
+`const`がデフォルトになった現代のコードでは、
+再代入されないことは`const`キーワードが既に表現しています。
+UPPER_SNAKE_CASEで「再代入されない」ことを重ねて示すのは冗長です。
+
+UPPER_SNAKE_CASEにすべき「真の定数」の判定は手間がかかります。
+主要なスタイルガイド(GoogleやAirbnb)も`const`を一律にUPPER_SNAKE_CASEにせよとは言っておらず、
+「モジュールレベルかつ意味的に深く不変なプリミティブ値」のような狭い条件に限定しています。
+`new`で生成したオブジェクトや関数、`RegExp`のように内部状態を持つ値は、
+`const`であってもこの基準では「定数ではない」のでcamelCaseが自然です。
+この境界はしばしば曖昧で、宣言のたびに判断するコストが高いです。
+
+ハードコードしていた値を後から計算式や引数に変えるリファクタリングをすると、
+UPPER_SNAKE_CASEのままでは名前を付け替える必要が出てきます。
+最初からcamelCaseで統一しておけばこの付け替えが発生しません。
+
+camelCaseに統一すれば、
+個々の変数が「真の定数」かどうかを判断する必要がなくなり、
+コードベース全体で一貫した命名になります。
+
+## 標準ライブラリやWeb APIの大文字定数について
+
+- `Math.PI`
+- `Number.MAX_SAFE_INTEGER`
+- `WebSocket.OPEN`
+
+のように標準ライブラリやWeb APIにはUPPER_SNAKE_CASE/UPPER_CASEの定数が存在します。
+
+これらは利用する側であって自分で命名するわけではないので、
+提供されている名前をそのまま使ってください。
+これらの存在は、
+自分のコードでUPPER_SNAKE_CASEを使う理由にはなりません。
+
+これらが大文字なのはC言語からJavaやWeb IDLへと受け継がれた歴史的慣習によるもので、
+いずれもプリミティブ型の固定値や整数の列挙値という限られた性質のものです。
+自分のコードがこの慣習に追従する義務はありません。
+
+## ESLintとの関係
+
+`@typescript-eslint/naming-convention`ルールのデフォルトは、
+`variable`に対して`camelCase`と`UPPER_CASE`の両方を許容します。
+したがってcamelCaseで統一してもlintは通ります。
+
+さらにcamelCaseだけに強制したい場合は、
+`variable`セレクタの`format`を`["camelCase"]`のみに設定できます。
+
+## 列挙的な定数値の定義
+
+複数の固定値をまとめて持つ定数オブジェクトや、
+文字列ユニオン型の元になる配列を定義する場合は、
+キーも値もUPPER_SNAKE_CASEにせず、
+camelCaseのオブジェクトに`as const`を付ける方法を優先します。
+詳細は[as-const-satisfies](../as-const-satisfies/SKILL.md)を参照してください。
+
+## プロジェクト内での一貫性
+
+プロジェクトやチームで既にUPPER_SNAKE_CASEの規約が採用されている場合は、
+そちらに従ってください。
+新規に方針を決められる場面でcamelCaseを優先するという指針であり、
+既存の規約を逐一覆すものではありません。


### PR DESCRIPTION
web-tasukeプラグインにTypeScript/JavaScriptのコーディングに関する知識スキルを追加します。

issue #239で挙げられていた一般的なガイドラインを、
それぞれ独立した知識スキルとして整備しました。

- `variable-naming`: 定数のように見える変数でもUPPER_SNAKE_CASEを避けてcamelCaseを優先する
- `avoid-for`: `for`文をなるべく避けて意図が明確な高抽象度の関数を優先する
- `prefer-specific-method`: 汎用的な関数より目的に特化した関数を優先する(`indexOf`より`includes`など)

いずれもClaudeが関連する文脈を検出すると自動的に参照するため、
より読みやすく意図の明確なコードを書く助けになります。

新しい知識スキルが追加されるため、
web-tasukeのマイナーバージョンを3.2.0に上げています。

close #239
