### PR TITLE
feat(haskell-tasuke): himariのimportを誘導するスキルを追加

### DIFF
--- a/plugins/haskell-tasuke/.claude-plugin/plugin.json
+++ b/plugins/haskell-tasuke/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "haskell-tasuke",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Haskell prompt for AI coding assistants.",
   "author": {
     "name": "ncaq",

--- a/plugins/haskell-tasuke/skills/himari/SKILL.md
+++ b/plugins/haskell-tasuke/skills/himari/SKILL.md
@@ -80,7 +80,7 @@ import Himari.Prelude
   - `UnliftIO.Async`
   - `UnliftIO.Directory`
   - `UnliftIO.Exception`
-- ログ: `Himari.Logger`の`logInfo`など
+- ログ: ロガーライブラリのre-exportで提供される`logInfo`など
 - Aeson: `Data.Aeson`系と`Deriving.Aeson`
 
 個別のモジュールのそのままimportしたら名前がコンフリクトする関数が必要になった場合は

--- a/plugins/haskell-tasuke/skills/himari/SKILL.md
+++ b/plugins/haskell-tasuke/skills/himari/SKILL.md
@@ -66,7 +66,7 @@ import Himari.Prelude
 - [ReaderT IO](https://academy.fpblock.com/blog/2017/06/readert-design-pattern/)パターンの、
   支援モナドと例えば以下の関数:
   - `newtype Himari env a = Himari { unHimari :: ReaderT env IO a }`
-  - `runHimari :: env -> Himari env a -> IO a`
+  - `runHimari :: (MonadIO m) => env -> Himari env a -> m a`
 - 文字列・コンテナ型、例えば以下:
   - `ByteString`
   - `HashMap`

--- a/plugins/haskell-tasuke/skills/himari/SKILL.md
+++ b/plugins/haskell-tasuke/skills/himari/SKILL.md
@@ -83,7 +83,8 @@ import Himari.Prelude
 - ログ: ロガーライブラリのre-exportで提供される`logInfo`など
 - Aeson: `Data.Aeson`系と`Deriving.Aeson`
 
-個別のモジュールのそのままimportしたら名前がコンフリクトする関数が必要になった場合は
+そのままimportしたら名前がコンフリクトしやすい、
+個別のモジュールに属する関数が必要になった場合は、
 qualified importが必要になります。
 その時のエイリアス規約の一部(himariのhlintルール由来)は以下の通りです。
 

--- a/plugins/haskell-tasuke/skills/himari/SKILL.md
+++ b/plugins/haskell-tasuke/skills/himari/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: himari
+description: himari is ncaq's rio-like custom Haskell Prelude. Import it with a single `import Himari`, never `import Himari.Prelude` or other submodules directly. Use when writing or reviewing Haskell code in a project that depends on the himari package.
+user-invocable: false
+---
+
+# himari
+
+[himari](https://github.com/ncaq/himari)は、
+ncaqが作成した、
+[rio](https://hackage.haskell.org/package/rio)
+の思想を受け継ぎつつ改良したカスタムPreludeライブラリです。
+
+- リポジトリ: <https://github.com/ncaq/himari>
+- Hackage: <https://hackage.haskell.org/package/himari>
+
+himariに依存するプロジェクトでは、
+`NoImplicitPrelude`が有効になっており、
+標準のPreludeの代わりにhimariを使います。
+
+## import は `import Himari` の1行だけ
+
+himariを使うモジュールでは、
+原則として以下の1行だけをimportします。
+
+```haskell
+import Himari
+```
+
+`Himari`モジュールが以下を全て再exportするエントリポイントだからです。
+
+- `Himari.Char`
+- `Himari.Env`
+- `Himari.Env.Simple`
+- `Himari.Logger`
+- `Himari.Prelude`
+
+## `import Himari.Prelude` を直接書かない
+
+`Himari.Prelude`などのサブモジュールを直接importするのは間違いです。
+
+```haskell
+-- 間違い: サブモジュールを直接importしている
+import Himari.Prelude
+```
+
+これをやると`Himari.Char`や`Himari.Env`や`Himari.Logger`などが漏れてしまい、
+本来使えるはずのシンボルが見つからなくなります。
+
+`Himari.Prelude`は`Himari`から再exportされるための内部モジュールであり、
+利用側が直接importするものではありません。
+
+同様に`Himari.SafePrelude`や`Himari.Prelude.Type`なども基本は直接importしません。
+全て`import Himari`で揃います。
+
+例外としては`Safe`言語拡張を使うモジュールで`Himari.SafePrelude`のみをimportするケースがあります。
+
+また`hiding`したけど一部だけrenameしてシンボルを利用したいこともあるかもしれませんが、
+これはqualified importの方を使うので稀でしょう。
+
+## 主なシンボルの出どころ
+
+`import Himari`で以下が利用可能になります。
+個別importは不要です。
+
+- [ReaderT IO](https://academy.fpblock.com/blog/2017/06/readert-design-pattern/)パターンの、
+  支援モナドと例えば以下の関数:
+  - `Himari env = ReaderT env IO`
+  - `runHimari :: env -> Himari env a -> IO a`
+- 文字列・コンテナ型、例えば以下:
+  - `ByteString`
+  - `HashMap`
+  - `Map`
+  - `NonEmpty`
+  - `Seq`
+  - `Set`
+  - `Text`
+  - `Vector`
+- IO・並行: `UnliftIO`系、例えば以下:
+  - `UnliftIO.Async`
+  - `UnliftIO.Directory`
+  - `UnliftIO.Exception`
+- ログ: `Himari.Logger`の`logInfo`など
+- Aeson: `Data.Aeson`系と`Deriving.Aeson`
+
+個別のモジュールのそのままimportしたら名前がコンフリクトする関数が必要になった場合は
+qualified importが必要になります。
+その時のエイリアス規約の一部(himariのhlintルール由来)は以下の通りです。
+
+- `Data.ByteString` → `qualified as B`
+- `Data.Text` → `qualified as T`
+- `Data.Map.Strict` → `qualified as Map`
+- `Data.List` → `qualified as L`
+
+## 関連するhaskell-tasukeスキル
+
+himari利用時も以下のhaskell-tasukeスキルの方針が当てはまります。
+
+- [haskell-tasuke:io-monad](../io-monad/SKILL.md):
+  `MonadIO`や`MonadUnliftIO`を優先する
+- [haskell-tasuke:lens](../lens/SKILL.md):
+  `makeFieldsId`でレコードのLensを生成し`HasLogAction`などを提供する
+- [haskell-tasuke:partial-function](../partial-function/SKILL.md):
+  部分関数を禁止する、himariのhlintルールが補助する
+- [haskell-tasuke:string](../string/SKILL.md):
+  `Text`を優先し、バイナリは`ByteString`を使う

--- a/plugins/haskell-tasuke/skills/himari/SKILL.md
+++ b/plugins/haskell-tasuke/skills/himari/SKILL.md
@@ -65,7 +65,7 @@ import Himari.Prelude
 
 - [ReaderT IO](https://academy.fpblock.com/blog/2017/06/readert-design-pattern/)パターンの、
   支援モナドと例えば以下の関数:
-  - `Himari env = ReaderT env IO`
+  - `newtype Himari env a = Himari { unHimari :: ReaderT env IO a }`
   - `runHimari :: env -> Himari env a -> IO a`
 - 文字列・コンテナ型、例えば以下:
   - `ByteString`


### PR DESCRIPTION
himariに依存するプロジェクトでのimportを誘導する`himari`スキルを追加しました。

himariはユーザのコードでは`import Himari`の1行だけを書くのが推奨ですが、
READMEを読ませても`import Himari.Prelude`とサブモジュールを直接importしてしまう事案が、
繰り返し発生していました。
サブモジュールを直接importすると`Himari.Char`や`Himari.Env`や`Himari.Logger`などが漏れて、
本来使えるはずのシンボルが見つからなくなります。

そこでhlintによる事後の機械的な指摘に頼るのではなく、
スキルとして`import Himari`の徹底を自然言語で誘導することにしました。
あわせて主要なシンボルの出どころ、
qualified importのエイリアス規約、
リポジトリやHackageへのリンク、
関連するhaskell-tasukeスキルへの誘導を記載しています。

himari固有のプラグインとして分離するのではなく、
haskell-tasukeにスキルを追加する形にしました。
ユーザにとっての機能追加のため、
haskell-tasukeのマイナーバージョンを上げました。

close #349
