### PR TITLE
feat: research関連の思考レベルを調整

### DIFF
--- a/plugins/research/.claude-plugin/plugin.json
+++ b/plugins/research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "research",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Research for information by fast agent.",
   "dependencies": ["nix-tasuke"],
   "author": {

--- a/plugins/research/agents/survey.md
+++ b/plugins/research/agents/survey.md
@@ -97,7 +97,7 @@ tools:
   - mcp__plugin_research_microsoft-learn__microsoft_docs_fetch
   - mcp__plugin_research_microsoft-learn__microsoft_docs_search
 model: sonnet
-effort: medium
+effort: low
 ---
 
 あらゆる情報ソースを横断検索して回答します。

--- a/plugins/research/skills/research/SKILL.md
+++ b/plugins/research/skills/research/SKILL.md
@@ -3,6 +3,8 @@ name: research
 description: Investigate any topic by querying multiple external sources (web, official docs, GitHub, MCP servers). Use whenever a question requires information not already in the working context, including library behavior, API specifications, error diagnostics, version comparisons, or general factual lookup.
 argument-hint: "query"
 allowed-tools: Agent(claude-code-guide), Agent(research:survey)
+model: opus
+effort: medium
 ---
 
 # クエリの分解


### PR DESCRIPTION
早く文献を読み漁って欲しいsurveyエージェントのeffortはlowに落とします。
情報をまとめる必要があるresearchスキルはある程度の思考能力を保ちつつ高速に動いて欲しいので、
forkしていないskillでどれぐらい効くかは正直不明ですが、
modelはopusを指定しつつ、
effortはmediumレベルまで落とします。
