### PR TITLE
build: npm側のprettierを削除してnixのprettierに一本化

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,6 @@
             let
               scriptList = [
                 "lint:eslint"
-                "lint:prettier"
                 "lint:tsc"
                 "test"
               ];

--- a/plugins/commit/package-lock.json
+++ b/plugins/commit/package-lock.json
@@ -23,7 +23,6 @@
         "eslint-plugin-n": "18.2.1",
         "jiti": "2.7.0",
         "npm-run-all2": "9.0.2",
-        "prettier": "3.8.4",
         "typescript": "6.0.3",
         "typescript-eslint": "8.62.1",
         "vite": "7.3.6",
@@ -3838,22 +3837,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/punycode": {

--- a/plugins/commit/package.json
+++ b/plugins/commit/package.json
@@ -6,10 +6,8 @@
     "build": "vite build",
     "fix": "run-p fix:*",
     "fix:eslint": "eslint --fix .",
-    "fix:prettier": "prettier --write .",
     "lint": "run-p lint:*",
     "lint:eslint": "eslint .",
-    "lint:prettier": "prettier --check .",
     "lint:tsc": "tsc --noEmit",
     "test": "vitest run --reporter=verbose"
   },
@@ -31,7 +29,6 @@
     "eslint-plugin-n": "18.2.1",
     "jiti": "2.7.0",
     "npm-run-all2": "9.0.2",
-    "prettier": "3.8.4",
     "typescript": "6.0.3",
     "typescript-eslint": "8.62.1",
     "vite": "7.3.6",

--- a/plugins/kyosei/package-lock.json
+++ b/plugins/kyosei/package-lock.json
@@ -31,7 +31,6 @@
         "eslint-plugin-n": "18.2.1",
         "jiti": "2.7.0",
         "npm-run-all2": "9.0.2",
-        "prettier": "3.8.4",
         "typescript": "6.0.3",
         "typescript-eslint": "8.62.1",
         "vite": "7.3.6",
@@ -4365,22 +4364,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/protocols": {

--- a/plugins/kyosei/package.json
+++ b/plugins/kyosei/package.json
@@ -6,10 +6,8 @@
     "build": "vite build",
     "fix": "run-p fix:*",
     "fix:eslint": "eslint --fix .",
-    "fix:prettier": "prettier --write .",
     "lint": "run-p lint:*",
     "lint:eslint": "eslint .",
-    "lint:prettier": "prettier --check .",
     "lint:tsc": "tsc --noEmit",
     "prepare": "effect-language-service patch",
     "test": "vitest run --reporter=verbose"
@@ -40,7 +38,6 @@
     "eslint-plugin-n": "18.2.1",
     "jiti": "2.7.0",
     "npm-run-all2": "9.0.2",
-    "prettier": "3.8.4",
     "typescript": "6.0.3",
     "typescript-eslint": "8.62.1",
     "vite": "7.3.6",

--- a/plugins/pr/package-lock.json
+++ b/plugins/pr/package-lock.json
@@ -23,7 +23,6 @@
         "eslint-plugin-n": "18.2.1",
         "jiti": "2.7.0",
         "npm-run-all2": "9.0.2",
-        "prettier": "3.8.4",
         "typescript": "6.0.3",
         "typescript-eslint": "8.62.1",
         "vite": "7.3.6",
@@ -3838,22 +3837,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/punycode": {

--- a/plugins/pr/package.json
+++ b/plugins/pr/package.json
@@ -6,10 +6,8 @@
     "build": "vite build",
     "fix": "run-p fix:*",
     "fix:eslint": "eslint --fix .",
-    "fix:prettier": "prettier --write .",
     "lint": "run-p lint:*",
     "lint:eslint": "eslint .",
-    "lint:prettier": "prettier --check .",
     "lint:tsc": "tsc --noEmit",
     "test": "vitest run --reporter=verbose"
   },
@@ -31,7 +29,6 @@
     "eslint-plugin-n": "18.2.1",
     "jiti": "2.7.0",
     "npm-run-all2": "9.0.2",
-    "prettier": "3.8.4",
     "typescript": "6.0.3",
     "typescript-eslint": "8.62.1",
     "vite": "7.3.6",


### PR DESCRIPTION
nixpkgs側のprettierとnpm側のprettierのバージョンが完全には一致せず、
フォーマット結果が衝突することがあったため。
prettierの特別な機能を利用しているわけではないので、
treefmt(nix fmt)で包括的にフォーマットする方が管理が楽です。

各プラグインの`package.json`から`fix:prettier`と`lint:prettier`のスクリプトと、
`prettier`のdevDependencyを削除し、
`flake.nix`のnpmチェック生成リストからも`lint:prettier`を削除します。

`eslint-config-prettier`はnix側のprettierによるフォーマットと、
ESLintルールの競合を防ぐために引き続き必要なので残します。
