### PR TITLE
refactor: nixチェックでeffect診断を検知してkyoseiの警告を解消

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,16 @@
                   };
                   nodeModules = pkgs.importNpmLock.buildNodeModules {
                     inherit nodejs npmRoot;
+                    derivationArgs = {
+                      # `importNpmLock`は`npm install --ignore-scripts`で依存を展開するため、
+                      # rootパッケージのprepareスクリプトが実行されない。
+                      # `effect-language-service patch`がtscにパッチを当てて、
+                      # effect診断をtscの診断の一部として有効化するパッケージがあるため、
+                      # `node_modules`がまだ書き込み可能なこの段階でprepareを実行する。
+                      preInstall = ''
+                        npm run --if-present prepare
+                      '';
+                    };
                   };
                   tsRoot = lib.fileset.toSource {
                     root = ./.;

--- a/plugins/kyosei/.claude-plugin/plugin.json
+++ b/plugins/kyosei/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "kyosei",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Code review for PRs or local changes. Covers code quality, dependency updates, performance, test coverage, documentation accuracy, and security.",
   "dependencies": ["research"],
   "author": {

--- a/plugins/kyosei/src/changeset.ts
+++ b/plugins/kyosei/src/changeset.ts
@@ -6,7 +6,9 @@
  */
 
 import { Command, type CommandExecutor } from "@effect/platform";
+import type { PlatformError } from "@effect/platform/Error";
 import { Data, Effect } from "effect";
+import type { UnknownException } from "effect/Cause";
 import type { Octokit } from "octokit";
 import type { GitHubOutputContext, LocalOutputContext, ReviewContext } from "./context-type";
 
@@ -36,7 +38,7 @@ export interface Changeset {
 function getPrChangeset(
   octokit: Octokit,
   context: GitHubOutputContext,
-): Effect.Effect<Changeset, Error> {
+): Effect.Effect<Changeset, UnexpectedDiffResponseType | UnknownException> {
   return Effect.gen(function* () {
     const [diffResponse, allCommits] = yield* Effect.all(
       [
@@ -96,7 +98,11 @@ Date: ${authorDate}
  */
 function getLocalChangeset(
   context: LocalOutputContext,
-): Effect.Effect<Changeset, Error, CommandExecutor.CommandExecutor> {
+): Effect.Effect<
+  Changeset,
+  UnexpectedDiffResponseType | PlatformError | UnknownException,
+  CommandExecutor.CommandExecutor
+> {
   return Effect.gen(function* () {
     const base =
       context.remoteName != null
@@ -120,7 +126,11 @@ function getLocalChangeset(
 export function getChangeset(
   octokit: Octokit,
   context: ReviewContext,
-): Effect.Effect<Changeset, Error, CommandExecutor.CommandExecutor> {
+): Effect.Effect<
+  Changeset,
+  UnexpectedDiffResponseType | PlatformError | UnknownException,
+  CommandExecutor.CommandExecutor
+> {
   if (context.output === "github") {
     return getPrChangeset(octokit, context);
   }

--- a/plugins/kyosei/src/changeset.ts
+++ b/plugins/kyosei/src/changeset.ts
@@ -6,9 +6,16 @@
  */
 
 import { Command, type CommandExecutor } from "@effect/platform";
-import { Effect } from "effect";
+import { Data, Effect } from "effect";
 import type { Octokit } from "octokit";
 import type { GitHubOutputContext, LocalOutputContext, ReviewContext } from "./context-type";
+
+/** mediaType diff指定に対して文字列以外のレスポンスが返ってきた場合の失敗。 */
+class UnexpectedDiffResponseType extends Data.TaggedError("UnexpectedDiffResponseType") {
+  override get message(): string {
+    return "unexpected response type for diff";
+  }
+}
 
 /**
  * レビュー対象の変更セット。
@@ -67,7 +74,7 @@ Date: ${authorDate}
       .join("\n");
     // mediaType diffを指定するとレスポンスが文字列になります。
     if (typeof diffResponse.data !== "string") {
-      return yield* Effect.fail(new Error("unexpected response type for diff"));
+      return yield* new UnexpectedDiffResponseType();
     }
     // コミット一覧の最後のエントリからPRのheadコミットSHAを取得します。
     // GitHub APIの`pulls.listCommits`は時系列昇順(古い順)で返すため、

--- a/plugins/kyosei/src/client.ts
+++ b/plugins/kyosei/src/client.ts
@@ -4,6 +4,7 @@
 
 import process from "node:process";
 import { Command, type CommandExecutor } from "@effect/platform";
+import type { PlatformError } from "@effect/platform/Error";
 import { Data, Effect, Option } from "effect";
 import { Octokit } from "octokit";
 
@@ -15,6 +16,31 @@ class EnvVarInvalidUrl extends Data.TaggedError("EnvVarInvalidUrl")<{
   readonly name: string;
   readonly cause: unknown;
 }> {}
+
+/** GitHub CLIからのトークン読み取りに失敗した場合の失敗。 */
+class GhTokenReadError extends Data.TaggedError("GhTokenReadError")<{
+  readonly cause: PlatformError;
+}> {
+  override get message(): string {
+    return `failed to read GitHub token from gh: ${this.cause.message}`;
+  }
+}
+
+/** GitHub CLIのトークン出力が事実上の空である場合の失敗。 */
+class GhTokenEmpty extends Data.TaggedError("GhTokenEmpty") {
+  override get message(): string {
+    return "gh auth token output is empty or whitespace only";
+  }
+}
+
+/** Octokitクライアントの生成に失敗した場合の失敗。 */
+export class OctokitClientCreationError extends Data.TaggedError("OctokitClientCreationError")<{
+  readonly cause: Error;
+}> {
+  override get message(): string {
+    return `failed to create Octokit client: ${this.cause.message}`;
+  }
+}
 
 /**
  * GitHubに認証するための情報。
@@ -71,7 +97,7 @@ function getUrlEnvironmentVariable(
   return Effect.gen(function* () {
     const value = getNormalizedEnvironmentVariable(name);
     if (Option.isNone(value)) {
-      return yield* Effect.fail(new EnvVarNotSet({ name }));
+      return yield* new EnvVarNotSet({ name });
     }
     return yield* Effect.try({
       try: () => new URL(value.value),
@@ -156,7 +182,7 @@ function getGitHubAuthOptionsFromEnvironment(): Option.Option<GitHubAuthOptions>
  */
 function createGitHubAuthOptionsFromGh(): Effect.Effect<
   GitHubAuthOptions,
-  Error,
+  EnvVarInvalidUrl | GhTokenReadError | GhTokenEmpty,
   CommandExecutor.CommandExecutor
 > {
   return Effect.gen(function* () {
@@ -166,13 +192,11 @@ function createGitHubAuthOptionsFromGh(): Effect.Effect<
         ? ["auth", "token"]
         : ["auth", "token", "--hostname", githubHostname];
     const stdout = yield* Command.string(Command.make("gh", ...argumentList)).pipe(
-      Effect.mapError(
-        (err) => new Error(`failed to read GitHub token from gh: ${err.message}`, { cause: err }),
-      ),
+      Effect.mapError((cause) => new GhTokenReadError({ cause })),
     );
     const token = normalizeEnvironmentVariable(stdout);
     if (Option.isNone(token)) {
-      return yield* Effect.fail(new Error("gh auth token output is empty or whitespace only"));
+      return yield* new GhTokenEmpty();
     }
     return {
       source: argumentList.join(" "),
@@ -187,7 +211,7 @@ function createGitHubAuthOptionsFromGh(): Effect.Effect<
  */
 function createGitHubAuthOptions(): Effect.Effect<
   GitHubAuthOptions,
-  Error,
+  EnvVarInvalidUrl | GhTokenReadError | GhTokenEmpty,
   CommandExecutor.CommandExecutor
 > {
   return Option.match(getGitHubAuthOptionsFromEnvironment(), {
@@ -239,7 +263,7 @@ function handleSecondaryRateLimit(
  */
 export function createOctokitClient(): Effect.Effect<
   Octokit,
-  Error,
+  OctokitClientCreationError,
   CommandExecutor.CommandExecutor
 > {
   return Effect.gen(function* () {
@@ -266,9 +290,5 @@ export function createOctokitClient(): Effect.Effect<
       },
       retry: { enabled: true },
     });
-  }).pipe(
-    Effect.mapError(
-      (err) => new Error(`failed to create Octokit client: ${err.message}`, { cause: err }),
-    ),
-  );
+  }).pipe(Effect.mapError((cause) => new OctokitClientCreationError({ cause })));
 }

--- a/plugins/kyosei/src/context-local.ts
+++ b/plugins/kyosei/src/context-local.ts
@@ -4,10 +4,19 @@
  */
 
 import { Command, type CommandExecutor } from "@effect/platform";
-import { Effect, Option } from "effect";
+import { Data, Effect, Option } from "effect";
 import type { Octokit } from "octokit";
 import type { LocalOutputContext } from "./context-type";
 import { getRemoteName, getRemoteRepo, type RemoteRepo } from "./remote";
+
+/** `git symbolic-ref`の出力が想定形式でない場合の失敗。 */
+class UnexpectedSymbolicRefFormat extends Data.TaggedError("UnexpectedSymbolicRefFormat")<{
+  readonly ref: string;
+}> {
+  override get message(): string {
+    return `unexpected symbolic-ref format: ${this.ref}`;
+  }
+}
 
 /**
  * gitのsymbolic-refからリモートのデフォルトブランチ名を取得します。
@@ -24,7 +33,7 @@ function getDefaultBranchFromGit(
     const prefix = `refs/remotes/${remoteName}/`;
     const ref = symbolicRef.trim();
     if (!ref.startsWith(prefix)) {
-      return yield* Effect.fail(new Error(`unexpected symbolic-ref format: ${ref}`));
+      return yield* new UnexpectedSymbolicRefFormat({ ref });
     }
     return ref.slice(prefix.length);
   });

--- a/plugins/kyosei/src/conversation.ts
+++ b/plugins/kyosei/src/conversation.ts
@@ -4,9 +4,18 @@
  * 追加ページがあればページネーションで全件取得します。
  */
 
-import { Effect } from "effect";
+import { Data, Effect } from "effect";
 import type { Octokit } from "octokit";
 import type { PrIdentifier } from "./context-type";
+
+/** GraphQLレスポンスに期待したconnectionが含まれていない場合の失敗。 */
+class GraphQlConnectionMissing extends Data.TaggedError("GraphQlConnectionMissing")<{
+  readonly connectionName: string;
+}> {
+  override get message(): string {
+    return `GraphQL response missing connection: ${this.connectionName}`;
+  }
+}
 
 // --- 出力型定義 ---
 
@@ -413,9 +422,7 @@ function paginateConnection<TNode>(
       );
       const connection = page.repository.pullRequest[connectionName];
       if (connection == null) {
-        return yield* Effect.fail(
-          new Error(`GraphQL response missing connection: ${connectionName}`),
-        );
+        return yield* new GraphQlConnectionMissing({ connectionName });
       }
       accumulator.push(...connection.nodes);
       hasNextPage = connection.pageInfo.hasNextPage;

--- a/plugins/kyosei/src/conversation.ts
+++ b/plugins/kyosei/src/conversation.ts
@@ -5,6 +5,7 @@
  */
 
 import { Data, Effect } from "effect";
+import type { UnknownException } from "effect/Cause";
 import type { Octokit } from "octokit";
 import type { PrIdentifier } from "./context-type";
 
@@ -408,7 +409,7 @@ function paginateConnection<TNode>(
   nodeFields: string,
   pageInfo: PageInfo,
   accumulator: TNode[],
-): Effect.Effect<void, Error> {
+): Effect.Effect<void, GraphQlConnectionMissing | UnknownException> {
   return Effect.gen(function* () {
     const query = buildPageQuery(connectionName, nodeFields);
     let cursor = pageInfo.endCursor;

--- a/plugins/kyosei/src/incremental-changeset.ts
+++ b/plugins/kyosei/src/incremental-changeset.ts
@@ -2,10 +2,19 @@
  * 前回レビュー対象コミットから現headまでの「増分changeset」を判定するモジュール。
  */
 
-import { Effect, Either, Schema } from "effect";
+import { Data, Effect, Either, Schema } from "effect";
 import type { Octokit } from "octokit";
 import type { PrIdentifier } from "./context-type";
 import { ShaSchema } from "./review-schema";
+
+/** GitHub APIからの増分changeset情報の取得に失敗した場合の失敗。 */
+class IncrementalChangesetLookupError extends Data.TaggedError("IncrementalChangesetLookupError")<{
+  readonly cause: unknown;
+}> {
+  override get message(): string {
+    return this.cause instanceof Error ? this.cause.message : String(this.cause);
+  }
+}
 
 const NonNegativeIntSchema = Schema.Number.pipe(Schema.int(), Schema.nonNegative());
 
@@ -48,7 +57,7 @@ function getCommitTreeSha(
   octokit: Octokit,
   target: PrIdentifier,
   sha: string,
-): Effect.Effect<string, Error> {
+): Effect.Effect<string, IncrementalChangesetLookupError> {
   return Effect.tryPromise({
     try: async () => {
       const response = await octokit.rest.git.getCommit({
@@ -58,7 +67,7 @@ function getCommitTreeSha(
       });
       return response.data.tree.sha;
     },
-    catch: (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+    catch: (cause) => new IncrementalChangesetLookupError({ cause }),
   });
 }
 
@@ -67,7 +76,7 @@ function compareCommits(
   target: PrIdentifier,
   baseSha: string,
   headSha: string,
-): Effect.Effect<CompareResult, Error> {
+): Effect.Effect<CompareResult, IncrementalChangesetLookupError> {
   return Effect.tryPromise({
     try: async () => {
       const response = await octokit.rest.repos.compareCommits({
@@ -86,7 +95,7 @@ function compareCommits(
           })) ?? [],
       };
     },
-    catch: (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+    catch: (cause) => new IncrementalChangesetLookupError({ cause }),
   });
 }
 
@@ -135,7 +144,26 @@ export function getIncrementalChangeset(
     const changedLineCount = sumLineChanges(compare.files);
 
     if (baseTreeSha === headTreeSha) {
-      return Schema.decodeUnknownSync(IncrementalChangesetSchema)({
+      // 内部で組み立てた値なのでデコード失敗はプログラムの欠陥として扱い、`orDie`で欠陥に変換します。
+      return yield* Effect.orDie(
+        Schema.decodeUnknown(IncrementalChangesetSchema)({
+          baseSha,
+          headSha,
+          baseTreeSha,
+          headTreeSha,
+          aheadBy: compare.aheadBy,
+          behindBy: compare.behindBy,
+          changedFileCount,
+          changedLineCount,
+          status: "tree-identical",
+        }),
+      );
+    }
+
+    const status: "diff-empty" | "diff-present" =
+      changedLineCount === 0 ? "diff-empty" : "diff-present";
+    return yield* Effect.orDie(
+      Schema.decodeUnknown(IncrementalChangesetSchema)({
         baseSha,
         headSha,
         baseTreeSha,
@@ -144,22 +172,8 @@ export function getIncrementalChangeset(
         behindBy: compare.behindBy,
         changedFileCount,
         changedLineCount,
-        status: "tree-identical",
-      });
-    }
-
-    const status: "diff-empty" | "diff-present" =
-      changedLineCount === 0 ? "diff-empty" : "diff-present";
-    return Schema.decodeUnknownSync(IncrementalChangesetSchema)({
-      baseSha,
-      headSha,
-      baseTreeSha,
-      headTreeSha,
-      aheadBy: compare.aheadBy,
-      behindBy: compare.behindBy,
-      changedFileCount,
-      changedLineCount,
-      status,
-    });
+        status,
+      }),
+    );
   });
 }

--- a/plugins/kyosei/src/remote.ts
+++ b/plugins/kyosei/src/remote.ts
@@ -58,7 +58,7 @@ export function getRemoteName(): Effect.Effect<
     const remoteListOutput = yield* Command.string(Command.make("git", "remote"));
     const firstRemote = remoteListOutput.trim().split("\n")[0];
     if (firstRemote == null || firstRemote === "") {
-      return yield* Effect.fail(new NoGitRemotes());
+      return yield* new NoGitRemotes();
     }
     return firstRemote;
   });
@@ -81,7 +81,7 @@ export function getRemoteRepo(): Effect.Effect<
     const url = remoteUrlOutput.trim();
     const parsed = gitUrlParse(url);
     if (parsed.owner === "" || parsed.name === "") {
-      return yield* Effect.fail(new RemoteUrlParseError({ url }));
+      return yield* new RemoteUrlParseError({ url });
     }
     return { remoteName, owner: parsed.owner, repo: parsed.name };
   });

--- a/plugins/kyosei/src/review-metadata.ts
+++ b/plugins/kyosei/src/review-metadata.ts
@@ -112,16 +112,20 @@ export function buildFooterView(
   return Effect.gen(function* () {
     const claudeCodeVersion = yield* detectClaudeCodeVersion();
     const runUrl = lookupRunUrlString();
-    return Schema.decodeUnknownSync(MetadataSchema)({
-      commit: submission.headCommitId,
-      pr: submission.prNumber,
-      kyoseiVersion: pluginManifest.version,
-      kyoseiActionVersion: process.env["KYOSEI_ACTION_VERSION"],
-      claudeCodeVersion: Option.getOrUndefined(claudeCodeVersion),
-      model: submission.metadata?.model,
-      execution: lookupExecution(),
-      ...(Option.isSome(runUrl) ? { runUrl: runUrl.value } : {}),
-    });
+    // 不正値は`MetadataSchema`が`"unknown"`に正規化するため、
+    // デコード失敗はプログラムの欠陥として扱い、`orDie`で欠陥に変換します。
+    return yield* Effect.orDie(
+      Schema.decodeUnknown(MetadataSchema)({
+        commit: submission.headCommitId,
+        pr: submission.prNumber,
+        kyoseiVersion: pluginManifest.version,
+        kyoseiActionVersion: process.env["KYOSEI_ACTION_VERSION"],
+        claudeCodeVersion: Option.getOrUndefined(claudeCodeVersion),
+        model: submission.metadata?.model,
+        execution: lookupExecution(),
+        ...(Option.isSome(runUrl) ? { runUrl: runUrl.value } : {}),
+      }),
+    );
   });
 }
 

--- a/plugins/kyosei/test/context-local.test.ts
+++ b/plugins/kyosei/test/context-local.test.ts
@@ -8,11 +8,12 @@ import { FakeCommandError, fakeCommandExecutor } from "./fake-command";
 const dummyOctokit = {} as Octokit;
 
 describe("resolveLocalContext", () => {
-  // ブランチ解決の入口で必ずgitが必要なので、フェイクで全コマンドを失敗させてrejectされることを確認します。
+  // ブランチ解決の入口で必ずgitが必要なので、
+  // フェイクで全コマンドを失敗させてrejectされることを確認します。
   it.effect("コマンド実行が全て失敗する場合は失敗で抜ける", () =>
     resolveLocalContext(dummyOctokit).pipe(
       Effect.flip,
-      Effect.tap((err) => Effect.sync(() => expect(err).toBeInstanceOf(Error))),
+      Effect.tap((err) => Effect.sync(() => expect(err).toBeInstanceOf(FakeCommandError))),
       Effect.provide(
         fakeCommandExecutor(() =>
           Effect.fail(new FakeCommandError({ message: "simulated git failure" })),

--- a/plugins/kyosei/test/context-local.test.ts
+++ b/plugins/kyosei/test/context-local.test.ts
@@ -3,7 +3,7 @@ import { Effect } from "effect";
 import type { Octokit } from "octokit";
 import { describe, expect } from "vitest";
 import { resolveLocalContext } from "../src/context-local";
-import { fakeCommandExecutor } from "./fake-command";
+import { FakeCommandError, fakeCommandExecutor } from "./fake-command";
 
 const dummyOctokit = {} as Octokit;
 
@@ -13,7 +13,11 @@ describe("resolveLocalContext", () => {
     resolveLocalContext(dummyOctokit).pipe(
       Effect.flip,
       Effect.tap((err) => Effect.sync(() => expect(err).toBeInstanceOf(Error))),
-      Effect.provide(fakeCommandExecutor(() => Effect.fail(new Error("simulated git failure")))),
+      Effect.provide(
+        fakeCommandExecutor(() =>
+          Effect.fail(new FakeCommandError({ message: "simulated git failure" })),
+        ),
+      ),
     ),
   );
 });

--- a/plugins/kyosei/test/context.test.ts
+++ b/plugins/kyosei/test/context.test.ts
@@ -4,12 +4,12 @@ import { Effect } from "effect";
 import type { Octokit } from "octokit";
 import { describe, expect } from "vitest";
 import { detectReviewContext } from "../src/context";
-import { fakeCommandExecutor } from "./fake-command";
+import { FakeCommandError, fakeCommandExecutor } from "./fake-command";
 
 const dummyOctokit = {} as Octokit;
 
 const failingCommandLayer = fakeCommandExecutor(() =>
-  Effect.fail(new Error("simulated git failure")),
+  Effect.fail(new FakeCommandError({ message: "simulated git failure" })),
 );
 
 describe("detectReviewContext", () => {

--- a/plugins/kyosei/test/context.test.ts
+++ b/plugins/kyosei/test/context.test.ts
@@ -13,7 +13,8 @@ const failingCommandLayer = fakeCommandExecutor(() =>
 );
 
 describe("detectReviewContext", () => {
-  // PR URLでない引数はローカル解決にフォールスルーするので、フェイクgitが失敗することでrejectされます。
+  // PR URLでない引数はローカル解決にフォールスルーするので、
+  // フェイクgitが失敗することでrejectされます。
   it.layer(failingCommandLayer)((it) => {
     const expectFailure = (
       argument: string | undefined,
@@ -22,7 +23,7 @@ describe("detectReviewContext", () => {
         // 成功してしまった場合はテストの前提が崩れているので`die`させて落とします。
         Effect.flip,
         Effect.orDie,
-        Effect.tap((err) => Effect.sync(() => expect(err).toBeInstanceOf(Error))),
+        Effect.tap((err) => Effect.sync(() => expect(err).toBeInstanceOf(FakeCommandError))),
         Effect.asVoid,
       );
 

--- a/plugins/kyosei/test/fake-command.ts
+++ b/plugins/kyosei/test/fake-command.ts
@@ -1,6 +1,7 @@
 /**
  * テスト用のフェイク`CommandExecutor`を構築するヘルパー。
- * `Command.string`の呼び出しだけをハンドラに委譲し、他のメソッドは未対応として`die`します。
+ * `Command.string`の呼び出しだけをハンドラに委譲し、
+ * 他のメソッドは未対応として`die`します。
  * テストがgitコマンド等の出力を制御したい時に使用します。
  */
 
@@ -15,7 +16,6 @@ export class FakeCommandError extends Data.TaggedError("FakeCommandError")<{
 
 /**
  * コマンド名と引数列に対する`stdout`をEffectで返すハンドラ。
- * 失敗時のエラーは任意の`Error`を許容します(本番では`PlatformError`ですが、テストでは生`Error`を流しやすくするため)。
  */
 export type CommandHandler = (
   command: string,
@@ -28,14 +28,12 @@ export function fakeCommandExecutor(
 ): Layer.Layer<CommandExecutor.CommandExecutor> {
   const fake: Pick<CommandExecutor.CommandExecutor, "string"> = {
     // `Command.flatten`はpipedな構造があっても先頭の`StandardCommand`を取り出せるので、
-    // バリアントを直接見ずに統一的に扱えます。テストではpipedは使わない前提で先頭のみ参照します。
+    // バリアントを直接見ずに統一的に扱えます。
     string: (cmd) => {
       const [standard] = Command.flatten(cmd);
       if (standard == null) {
         return Effect.die(new Error("fakeCommandExecutor: empty Command.flatten result"));
       }
-      // テスト用に`Error`で失敗させたものは`PlatformError`として扱われますが、
-      // テスト側では`Effect.either`等で受け取って中身を比較するだけなので、型情報を緩めて流しています。
       return handler(standard.command, standard.args) as Effect.Effect<string, PlatformError>;
     },
   };

--- a/plugins/kyosei/test/fake-command.ts
+++ b/plugins/kyosei/test/fake-command.ts
@@ -6,7 +6,12 @@
 
 import { Command, CommandExecutor } from "@effect/platform";
 import type { PlatformError } from "@effect/platform/Error";
-import { Effect, Layer } from "effect";
+import { Data, Effect, Layer } from "effect";
+
+/** テストでコマンド実行の失敗を模倣するためのタグ付きエラー。 */
+export class FakeCommandError extends Data.TaggedError("FakeCommandError")<{
+  readonly message: string;
+}> {}
 
 /**
  * コマンド名と引数列に対する`stdout`をEffectで返すハンドラ。

--- a/plugins/kyosei/test/remote.test.ts
+++ b/plugins/kyosei/test/remote.test.ts
@@ -2,7 +2,7 @@ import { it } from "@effect/vitest";
 import { Effect } from "effect";
 import { describe, expect } from "vitest";
 import { getRemoteName, getRemoteRepo, NoGitRemotes } from "../src/remote";
-import { fakeCommandExecutor, type CommandHandler } from "./fake-command";
+import { FakeCommandError, fakeCommandExecutor, type CommandHandler } from "./fake-command";
 
 const sequenceHandler = (responses: Effect.Effect<string, Error>[]): CommandHandler => {
   let index = 0;
@@ -29,7 +29,7 @@ describe("getRemoteName", () => {
       Effect.provide(
         fakeCommandExecutor(
           sequenceHandler([
-            Effect.fail(new Error("fatal: no upstream configured")),
+            Effect.fail(new FakeCommandError({ message: "fatal: no upstream configured" })),
             Effect.succeed("upstream\norigin\n"),
           ]),
         ),
@@ -44,7 +44,7 @@ describe("getRemoteName", () => {
       Effect.provide(
         fakeCommandExecutor(
           sequenceHandler([
-            Effect.fail(new Error("fatal: no upstream configured")),
+            Effect.fail(new FakeCommandError({ message: "fatal: no upstream configured" })),
             Effect.succeed("\n"),
           ]),
         ),

--- a/plugins/kyosei/test/review-metadata-parser.test.ts
+++ b/plugins/kyosei/test/review-metadata-parser.test.ts
@@ -4,10 +4,10 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { decodeReviewSubmission } from "../src/review-decoder";
 import { buildReviewBody } from "../src/review-metadata";
 import { parseFooterMetadata } from "../src/review-metadata-parser";
-import { fakeCommandExecutor } from "./fake-command";
+import { FakeCommandError, fakeCommandExecutor } from "./fake-command";
 
 const claudeFakeLayer = fakeCommandExecutor(() =>
-  Effect.fail(new Error("claude not installed in test environment")),
+  Effect.fail(new FakeCommandError({ message: "claude not installed in test environment" })),
 );
 
 const baseInput = {

--- a/plugins/kyosei/test/review-metadata.test.ts
+++ b/plugins/kyosei/test/review-metadata.test.ts
@@ -3,11 +3,11 @@ import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { decodeReviewSubmission } from "../src/review-decoder";
 import { buildFooterView, buildReviewBody } from "../src/review-metadata";
-import { fakeCommandExecutor } from "./fake-command";
+import { FakeCommandError, fakeCommandExecutor } from "./fake-command";
 
 // `claude --version`の呼び出しを失敗させ、`Option.none`にフォールバックさせます。
 const claudeFakeLayer = fakeCommandExecutor(() =>
-  Effect.fail(new Error("claude not installed in test environment")),
+  Effect.fail(new FakeCommandError({ message: "claude not installed in test environment" })),
 );
 
 const baseInput = {

--- a/plugins/kyosei/test/review-poster.test.ts
+++ b/plugins/kyosei/test/review-poster.test.ts
@@ -4,10 +4,10 @@ import type { Octokit } from "octokit";
 import { describe, expect, vi } from "vitest";
 import { decodeReviewSubmission } from "../src/review-decoder";
 import { previewReview, submitReview } from "../src/review-poster";
-import { fakeCommandExecutor } from "./fake-command";
+import { FakeCommandError, fakeCommandExecutor } from "./fake-command";
 
 const claudeFakeLayer = fakeCommandExecutor(() =>
-  Effect.fail(new Error("claude not installed in test environment")),
+  Effect.fail(new FakeCommandError({ message: "claude not installed in test environment" })),
 );
 
 /** テスト用の最小限の有効な入力。 */


### PR DESCRIPTION
kyoseiでローカルの`npm run lint`を実行すると、
effect language serviceの診断が警告として報告されて失敗していましたが、
nix側のチェック(CI)では同じ警告を検知できず素通りしていました。

原因は`importNpmLock.buildNodeModules`が`npm install --ignore-scripts`で依存を展開するため、
prepareスクリプトの`effect-language-service patch`が実行されず、
nix側ではパッチなしのtscが診断を報告しないことでした。

このPRでは以下を行います。

`node_modules`がまだ書き込み可能なビルド段階で`npm run --if-present prepare`を実行し、
ローカルと同じパッチ済みtscでCIのチェックが動くようにします。
これによりeffect診断の警告が今後はCIで検知されます。

その上で、検知対象となった既存の警告を全て解消します。
生の`Error`をEffectの失敗チャンネルに流していた箇所を、
既存の流儀に合わせた`Data.TaggedError`に置き換え、
`Effect.gen`内の`Schema.decodeUnknownSync`を`Schema.decodeUnknown` + `Effect.orDie`に置き換えます。
エラーメッセージの文言や欠陥扱いの意味論は従来のまま維持しています。

ユーザから見える動作は変わらないためkyoseiは3.5.1へのパッチアップに留めます。

https://claude.ai/code/session_01XiAPQyAUYumSmwZC2sYH3d