### PR TITLE
fix(commit, pr): fableの節約と生成品質を担保するため`model: opus`を指定します

### DIFF
--- a/plugins/commit/.claude-plugin/plugin.json
+++ b/plugins/commit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "commit",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "Generate a commit message from staged changes and let the user review before committing. Use when the user wants to commit changes or create a git commit.",
   "author": {
     "name": "ncaq",

--- a/plugins/commit/skills/commit/SKILL.md
+++ b/plugins/commit/skills/commit/SKILL.md
@@ -2,6 +2,7 @@
 name: commit
 description: Generate a commit message from staged changes and let the user review before committing. Use when the user wants to commit changes or create a git commit.
 allowed-tools: AskUserQuestion, Bash(commit-prepare:*), Bash(git commit:*), Bash(konoka-commit-editor:*), Edit, Read, Write, Skill(commit-style)
+model: opus
 effort: medium
 ---
 

--- a/plugins/pr/.claude-plugin/plugin.json
+++ b/plugins/pr/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "pr",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Create a GitHub pull request from the current branch.",
   "dependencies": ["commit"],
   "author": {

--- a/plugins/pr/skills/pr/SKILL.md
+++ b/plugins/pr/skills/pr/SKILL.md
@@ -2,6 +2,7 @@
 name: pr
 description: Generate a GitHub pull request title and body from the current branch and let the user review before creation. Use when the user wants to create a pull request.
 allowed-tools: AskUserQuestion, Bash(git status:*), Bash(konoka-pr-editor:*), Bash(prepare-editmsg:*), Bash(sync-and-push:*), Edit, Read, Skill(pr-style), Write, mcp__github__create_pull_request, mcp__github__issue_write
+model: opus
 effort: medium
 ---
 


### PR DESCRIPTION
`commit`と`pr`スキルはコミットメッセージやPR本文といった、
ある程度軽量な作業を行うため、
fableは過剰でレートリミットを無駄に消費してしまうため、
opusに留めます。

スキル`frontmatter`の`model`は公式にサポートされており、
スキル実行のターン内に限りメインループのモデルが切り替わるので、
セッション全体のモデル選択には影響しません。

ユーザから見た外部インタフェース(呼び出し方や出力形態)は変わらないため、
それぞれのプラグインは`patch`バージョンアップに留めます。
