### PR TITLE
build(deps): effect関連パッケージを最新版に更新

### DIFF
--- a/plugins/commit/package-lock.json
+++ b/plugins/commit/package-lock.json
@@ -6,14 +6,14 @@
     "": {
       "name": "konoka-commit",
       "dependencies": {
-        "@effect/cli": "0.75.2",
-        "@effect/platform": "0.96.2",
-        "@effect/platform-node": "0.107.0",
-        "effect": "3.21.4"
+        "@effect/cli": "0.76.0",
+        "@effect/platform": "0.97.0",
+        "@effect/platform-node": "0.108.0",
+        "effect": "3.22.0"
       },
       "devDependencies": {
         "@effect/language-service": "0.87.0",
-        "@effect/vitest": "0.29.0",
+        "@effect/vitest": "0.30.0",
         "@eslint/js": "10.0.1",
         "@types/node": "22.20.1",
         "eslint": "10.7.0",
@@ -33,9 +33,9 @@
       }
     },
     "node_modules/@effect/cli": {
-      "version": "0.75.2",
-      "resolved": "https://registry.npmjs.org/@effect/cli/-/cli-0.75.2.tgz",
-      "integrity": "sha512-+cMn/ZtFB+jEvgB6phrTT6XyPkIUnmX4G0nUSln7yj3lwyiHQ578Iwr8nHeU1CKEtlh4Xt+mYc0yiT912xu7YA==",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@effect/cli/-/cli-0.76.0.tgz",
+      "integrity": "sha512-6N6u827Brlvf1UF3WMUazUgzZxq3kN/jemj66El7CUNulmlU7ciYKV0UMpETculvkKTfVonHZ5s49Fdz6Ad0cQ==",
       "license": "MIT",
       "dependencies": {
         "ini": "^4.1.3",
@@ -43,41 +43,41 @@
         "yaml": "^2.5.0"
       },
       "peerDependencies": {
-        "@effect/platform": "^0.96.1",
-        "@effect/printer": "^0.49.0",
-        "@effect/printer-ansi": "^0.49.0",
-        "effect": "^3.21.2"
+        "@effect/platform": "^0.97.0",
+        "@effect/printer": "^0.50.0",
+        "@effect/printer-ansi": "^0.50.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/cluster": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@effect/cluster/-/cluster-0.59.0.tgz",
-      "integrity": "sha512-rxtJ0zlcdDDtn9wau0z/PFfwPP2FsYPB2/tSK4tT8DkTYQmACJ5AwRwZm3Ea83iL/gv3df63lRe94oMiS8bFfg==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@effect/cluster/-/cluster-0.60.0.tgz",
+      "integrity": "sha512-O98Qx8jzEBhizhV/nOiqkZx+b0kx0AB1FBX+AKJ8wR8XO5Le44jqFzBwhwcoOVRhKVr2wzp3OE+IthipCVh4Mg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "kubernetes-types": "^1.30.0"
       },
       "peerDependencies": {
-        "@effect/platform": "^0.96.1",
-        "@effect/rpc": "^0.75.1",
-        "@effect/sql": "^0.51.1",
-        "@effect/workflow": "^0.18.2",
-        "effect": "^3.21.2"
+        "@effect/platform": "^0.97.0",
+        "@effect/rpc": "^0.76.0",
+        "@effect/sql": "^0.52.0",
+        "@effect/workflow": "^0.19.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/experimental": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@effect/experimental/-/experimental-0.60.0.tgz",
-      "integrity": "sha512-i5zIg7Xup2KgHyqHlYtkgqSE1bNzCL0GbbTQxrpIzKF0q/ebknOk/ox8B/gIq2vImjoEE81h/oxU+6i1NH210g==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@effect/experimental/-/experimental-0.61.0.tgz",
+      "integrity": "sha512-kv/ZORw2RMau74Q6Pco9/RTf/iXczBDqStHI9K8dP/1pUFq+dUMa4fHptuf3IIAe3tYdx4ALYsLyFLVcg+C5iQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "uuid": "^11.0.3"
       },
       "peerDependencies": {
-        "@effect/platform": "^0.96.0",
-        "effect": "^3.21.0",
+        "@effect/platform": "^0.97.0",
+        "effect": "^3.22.0",
         "ioredis": "^5",
         "lmdb": "^3"
       },
@@ -101,9 +101,9 @@
       }
     },
     "node_modules/@effect/platform": {
-      "version": "0.96.2",
-      "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.96.2.tgz",
-      "integrity": "sha512-oJm3UztdzZvK7BXkFSV3IdyGuqQrhLmViG/hMDZh99ski7aADesNuv19z4R0heH3bAXnSt/Nb8O9KJQ886C0Tg==",
+      "version": "0.97.0",
+      "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.97.0.tgz",
+      "integrity": "sha512-PPSKkQ+QlIbKcf74FZKi3pi2h8hqYjsrUYaFuWXsuHpr8gjUoNNxJBptYzkzy4X9f7EeHhHqDMcj9YxaMygiHg==",
       "license": "MIT",
       "dependencies": {
         "find-my-way-ts": "^0.1.6",
@@ -111,32 +111,32 @@
         "multipasta": "^0.2.7"
       },
       "peerDependencies": {
-        "effect": "^3.21.4"
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/platform-node": {
-      "version": "0.107.0",
-      "resolved": "https://registry.npmjs.org/@effect/platform-node/-/platform-node-0.107.0.tgz",
-      "integrity": "sha512-VWUD9SCcnsrXYqED2jIwDHHDGb3QePNsHlX7HfqQGD2/AgnfX9jNnecaFrJj7Rf2gK5VbRE+i/2oNFoC/DkhcA==",
+      "version": "0.108.0",
+      "resolved": "https://registry.npmjs.org/@effect/platform-node/-/platform-node-0.108.0.tgz",
+      "integrity": "sha512-AA8j4e7TOOzBOFAhYcwrtO0pGytiWxEpD7/xWs1nER+JyZI9la+Y506A72uWzc0GiOMBSPcsRmqc5zBjgImCZQ==",
       "license": "MIT",
       "dependencies": {
-        "@effect/platform-node-shared": "^0.60.0",
+        "@effect/platform-node-shared": "^0.61.0",
         "mime": "^3.0.0",
         "undici": "^7.10.0",
         "ws": "^8.18.2"
       },
       "peerDependencies": {
-        "@effect/cluster": "^0.59.0",
-        "@effect/platform": "^0.96.1",
-        "@effect/rpc": "^0.75.1",
-        "@effect/sql": "^0.51.1",
-        "effect": "^3.21.2"
+        "@effect/cluster": "^0.60.0",
+        "@effect/platform": "^0.97.0",
+        "@effect/rpc": "^0.76.0",
+        "@effect/sql": "^0.52.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/platform-node-shared": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@effect/platform-node-shared/-/platform-node-shared-0.60.0.tgz",
-      "integrity": "sha512-obT8Mau/guSYjehF9pg09FHM/ERXAAVBl/FXRXEyvTc7ZiDGTYnPBihytGNccsfNsgqBdvCE24sflwK6j5nFXA==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@effect/platform-node-shared/-/platform-node-shared-0.61.0.tgz",
+      "integrity": "sha512-68KbcnItrKFgDinFOmBVSABjcXBjp4vZbOUI3piFh87ZK/55vQ8+bwKGU4X7R9Vz1lSehyz5m2e7hwWVq3GNrg==",
       "license": "MIT",
       "dependencies": {
         "@parcel/watcher": "^2.5.1",
@@ -144,99 +144,99 @@
         "ws": "^8.18.2"
       },
       "peerDependencies": {
-        "@effect/cluster": "^0.59.0",
-        "@effect/platform": "^0.96.1",
-        "@effect/rpc": "^0.75.1",
-        "@effect/sql": "^0.51.1",
-        "effect": "^3.21.2"
+        "@effect/cluster": "^0.60.0",
+        "@effect/platform": "^0.97.0",
+        "@effect/rpc": "^0.76.0",
+        "@effect/sql": "^0.52.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/printer": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@effect/printer/-/printer-0.49.0.tgz",
-      "integrity": "sha512-hrjTuExF87wuWjOnnND1c2fKcCWhleQBVaoA7JlrU3rC7s+RYPETDOXtpgAK3/uuMCRnDhfVFQMevtKT8MBdKg==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@effect/printer/-/printer-0.50.0.tgz",
+      "integrity": "sha512-9tV9tNJS+Mjw+ZkBrfX3oUw9Kj5Ay61XMq0sONIUiBc6IgmJnLRmS12D/GTCVYncVmcX9zVrllhvN99StdcETg==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@effect/typeclass": "^0.40.0",
-        "effect": "^3.21.0"
+        "@effect/typeclass": "^0.41.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/printer-ansi": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@effect/printer-ansi/-/printer-ansi-0.49.0.tgz",
-      "integrity": "sha512-N2OyqDTqcGLKeUy2URowThoU5issZQwG/Ihv5qOYWJD0neq9qBIgC57/9BkFpTRPNSMtPHyCOk1TFj297HGLLQ==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@effect/printer-ansi/-/printer-ansi-0.50.0.tgz",
+      "integrity": "sha512-m2eVY1EcHRAQitweIcLUlZohRO4P96pyjiS8p31064CFddsY4qwXrP0I5h39T7D91gutM3Cru6VUDnw20rNyeA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@effect/printer": "^0.49.0"
+        "@effect/printer": "^0.50.0"
       },
       "peerDependencies": {
-        "@effect/typeclass": "^0.40.0",
-        "effect": "^3.21.0"
+        "@effect/typeclass": "^0.41.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/rpc": {
-      "version": "0.75.1",
-      "resolved": "https://registry.npmjs.org/@effect/rpc/-/rpc-0.75.1.tgz",
-      "integrity": "sha512-8yxF8+mMGGEbF8BUCp34HjdJj7CvTpGeZxBcpsDF6v7zPiGbJL1UDLzA8ZqYjmcngBHhPecbmeONTk/LiLAaEg==",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@effect/rpc/-/rpc-0.76.0.tgz",
+      "integrity": "sha512-51lcJtpy6ls9GnS6VqYBLeZq4xziUCHqdb/FkEDp9NO4WEIZfO+u/mfYUiAqMf3uiyr/GgrC1+JGIblf9Brqow==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "msgpackr": "^1.11.10"
       },
       "peerDependencies": {
-        "@effect/platform": "^0.96.1",
-        "effect": "^3.21.2"
+        "@effect/platform": "^0.97.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/sql": {
-      "version": "0.51.1",
-      "resolved": "https://registry.npmjs.org/@effect/sql/-/sql-0.51.1.tgz",
-      "integrity": "sha512-iPDAefrJcI0HcTk9keP9Gq8Pg08K1HmpnmZZt85AqyTcvorhoNsXDFiKBbPldfV2CortwVkacX8KjO9GPpSYCA==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@effect/sql/-/sql-0.52.0.tgz",
+      "integrity": "sha512-S7z9grD8QmuQDjM7VZLA3RsyQt9TKL/uSyjsz9Oz+gqBA4Espu+8dLDCc1OCWxVWUbUnfGH4L6rv4pSsX598iA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "uuid": "^11.0.3"
       },
       "peerDependencies": {
-        "@effect/experimental": "^0.60.0",
-        "@effect/platform": "^0.96.1",
-        "effect": "^3.21.2"
+        "@effect/experimental": "^0.61.0",
+        "@effect/platform": "^0.97.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/typeclass": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@effect/typeclass/-/typeclass-0.40.0.tgz",
-      "integrity": "sha512-L/2o2ImeqbemFlqH0b3y2PqQTFc+E0/DUnffCU8bkJUGh0yUZmh2RXuXhR8QOpfNCe718JQjI+mLnpVF2MMmaQ==",
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@effect/typeclass/-/typeclass-0.41.0.tgz",
+      "integrity": "sha512-Tsv94iDPUWgmz/JsYUh7awx5mmFukEJZB+duyzlLRlCHxNUz5LHBBzTaEfUPNMzAE1s8FTUSVwdPSpL0DznXKg==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "effect": "^3.21.0"
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/vitest": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@effect/vitest/-/vitest-0.29.0.tgz",
-      "integrity": "sha512-DvWr1aeEcaZ8mtu8hNVb4e3rEYvGEwQSr7wsNrW53t6nKYjkmjRICcvVEsXUhjoCblRHSxRsRV0TOt0+UmcvaQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@effect/vitest/-/vitest-0.30.0.tgz",
+      "integrity": "sha512-2qcK7F4XSwOn7Ye9vgEkrndHiiHVf9Nl+U5jvvLBKeYx4+8++O5Y8RFezaQzs/rWx8GkdlStv/s+HYMHZ/2/AQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "effect": "^3.21.0",
+        "effect": "^3.22.0",
         "vitest": "^3.2.0"
       }
     },
     "node_modules/@effect/workflow": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/@effect/workflow/-/workflow-0.18.2.tgz",
-      "integrity": "sha512-2av0TexhxHnapQa3eLn6TkniokUFRZKf8dlWlLqbODMpXAJ3mm+DOHWM0ozMGkg9K/+zGCtiL3dMqJyJ8r7G8g==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@effect/workflow/-/workflow-0.19.0.tgz",
+      "integrity": "sha512-9x84bADzhVWrglxWW3ts3LzoojMLAJ8SpR+Bv3YaZ3LToXrxTYnJZ29vR6X5VyK35rpQ7DtTruAT3JnQKmIEXw==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@effect/experimental": "^0.60.0",
-        "@effect/platform": "^0.96.1",
-        "@effect/rpc": "^0.75.1",
-        "effect": "^3.21.2"
+        "@effect/experimental": "^0.61.0",
+        "@effect/platform": "^0.97.0",
+        "@effect/rpc": "^0.76.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2662,9 +2662,9 @@
       }
     },
     "node_modules/effect": {
-      "version": "3.21.4",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.4.tgz",
-      "integrity": "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.22.0.tgz",
+      "integrity": "sha512-jhYFe0zTlIRqYFrKTS+6luhmS/Tm0f+JLo0K9KUxvtFab1SUGEszQi2ehOP6QzAZvy831lDmTwwzvVDZSPNz3g==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",

--- a/plugins/commit/package.json
+++ b/plugins/commit/package.json
@@ -12,14 +12,14 @@
     "test": "vitest run --reporter=verbose"
   },
   "dependencies": {
-    "@effect/cli": "0.75.2",
-    "@effect/platform": "0.96.2",
-    "@effect/platform-node": "0.107.0",
-    "effect": "3.21.4"
+    "@effect/cli": "0.76.0",
+    "@effect/platform": "0.97.0",
+    "@effect/platform-node": "0.108.0",
+    "effect": "3.22.0"
   },
   "devDependencies": {
     "@effect/language-service": "0.87.0",
-    "@effect/vitest": "0.29.0",
+    "@effect/vitest": "0.30.0",
     "@eslint/js": "10.0.1",
     "@types/node": "22.20.1",
     "eslint": "10.7.0",

--- a/plugins/kyosei/package-lock.json
+++ b/plugins/kyosei/package-lock.json
@@ -6,10 +6,10 @@
     "": {
       "name": "konoka-kyosei",
       "dependencies": {
-        "@effect/cli": "^0.75.1",
-        "@effect/platform": "^0.96.1",
-        "@effect/platform-node": "^0.107.0",
-        "effect": "^3.21.1",
+        "@effect/cli": "^0.76.0",
+        "@effect/platform": "^0.97.0",
+        "@effect/platform-node": "^0.108.0",
+        "effect": "^3.22.0",
         "fp-ts": "^2.16.11",
         "git-url-parse": "^16.1.0",
         "mustache": "^4.2.0",
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@effect/language-service": "0.87.0",
-        "@effect/vitest": "0.29.0",
+        "@effect/vitest": "0.30.0",
         "@eslint/js": "10.0.1",
         "@types/mustache": "4.2.6",
         "@types/node": "22.20.1",
@@ -64,9 +64,9 @@
       }
     },
     "node_modules/@effect/cli": {
-      "version": "0.75.2",
-      "resolved": "https://registry.npmjs.org/@effect/cli/-/cli-0.75.2.tgz",
-      "integrity": "sha512-+cMn/ZtFB+jEvgB6phrTT6XyPkIUnmX4G0nUSln7yj3lwyiHQ578Iwr8nHeU1CKEtlh4Xt+mYc0yiT912xu7YA==",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@effect/cli/-/cli-0.76.0.tgz",
+      "integrity": "sha512-6N6u827Brlvf1UF3WMUazUgzZxq3kN/jemj66El7CUNulmlU7ciYKV0UMpETculvkKTfVonHZ5s49Fdz6Ad0cQ==",
       "license": "MIT",
       "dependencies": {
         "ini": "^4.1.3",
@@ -74,41 +74,41 @@
         "yaml": "^2.5.0"
       },
       "peerDependencies": {
-        "@effect/platform": "^0.96.1",
-        "@effect/printer": "^0.49.0",
-        "@effect/printer-ansi": "^0.49.0",
-        "effect": "^3.21.2"
+        "@effect/platform": "^0.97.0",
+        "@effect/printer": "^0.50.0",
+        "@effect/printer-ansi": "^0.50.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/cluster": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@effect/cluster/-/cluster-0.59.0.tgz",
-      "integrity": "sha512-rxtJ0zlcdDDtn9wau0z/PFfwPP2FsYPB2/tSK4tT8DkTYQmACJ5AwRwZm3Ea83iL/gv3df63lRe94oMiS8bFfg==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@effect/cluster/-/cluster-0.60.0.tgz",
+      "integrity": "sha512-O98Qx8jzEBhizhV/nOiqkZx+b0kx0AB1FBX+AKJ8wR8XO5Le44jqFzBwhwcoOVRhKVr2wzp3OE+IthipCVh4Mg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "kubernetes-types": "^1.30.0"
       },
       "peerDependencies": {
-        "@effect/platform": "^0.96.1",
-        "@effect/rpc": "^0.75.1",
-        "@effect/sql": "^0.51.1",
-        "@effect/workflow": "^0.18.2",
-        "effect": "^3.21.2"
+        "@effect/platform": "^0.97.0",
+        "@effect/rpc": "^0.76.0",
+        "@effect/sql": "^0.52.0",
+        "@effect/workflow": "^0.19.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/experimental": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@effect/experimental/-/experimental-0.60.0.tgz",
-      "integrity": "sha512-i5zIg7Xup2KgHyqHlYtkgqSE1bNzCL0GbbTQxrpIzKF0q/ebknOk/ox8B/gIq2vImjoEE81h/oxU+6i1NH210g==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@effect/experimental/-/experimental-0.61.0.tgz",
+      "integrity": "sha512-kv/ZORw2RMau74Q6Pco9/RTf/iXczBDqStHI9K8dP/1pUFq+dUMa4fHptuf3IIAe3tYdx4ALYsLyFLVcg+C5iQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "uuid": "^11.0.3"
       },
       "peerDependencies": {
-        "@effect/platform": "^0.96.0",
-        "effect": "^3.21.0",
+        "@effect/platform": "^0.97.0",
+        "effect": "^3.22.0",
         "ioredis": "^5",
         "lmdb": "^3"
       },
@@ -132,9 +132,9 @@
       }
     },
     "node_modules/@effect/platform": {
-      "version": "0.96.2",
-      "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.96.2.tgz",
-      "integrity": "sha512-oJm3UztdzZvK7BXkFSV3IdyGuqQrhLmViG/hMDZh99ski7aADesNuv19z4R0heH3bAXnSt/Nb8O9KJQ886C0Tg==",
+      "version": "0.97.0",
+      "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.97.0.tgz",
+      "integrity": "sha512-PPSKkQ+QlIbKcf74FZKi3pi2h8hqYjsrUYaFuWXsuHpr8gjUoNNxJBptYzkzy4X9f7EeHhHqDMcj9YxaMygiHg==",
       "license": "MIT",
       "dependencies": {
         "find-my-way-ts": "^0.1.6",
@@ -142,32 +142,32 @@
         "multipasta": "^0.2.7"
       },
       "peerDependencies": {
-        "effect": "^3.21.4"
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/platform-node": {
-      "version": "0.107.0",
-      "resolved": "https://registry.npmjs.org/@effect/platform-node/-/platform-node-0.107.0.tgz",
-      "integrity": "sha512-VWUD9SCcnsrXYqED2jIwDHHDGb3QePNsHlX7HfqQGD2/AgnfX9jNnecaFrJj7Rf2gK5VbRE+i/2oNFoC/DkhcA==",
+      "version": "0.108.0",
+      "resolved": "https://registry.npmjs.org/@effect/platform-node/-/platform-node-0.108.0.tgz",
+      "integrity": "sha512-AA8j4e7TOOzBOFAhYcwrtO0pGytiWxEpD7/xWs1nER+JyZI9la+Y506A72uWzc0GiOMBSPcsRmqc5zBjgImCZQ==",
       "license": "MIT",
       "dependencies": {
-        "@effect/platform-node-shared": "^0.60.0",
+        "@effect/platform-node-shared": "^0.61.0",
         "mime": "^3.0.0",
         "undici": "^7.10.0",
         "ws": "^8.18.2"
       },
       "peerDependencies": {
-        "@effect/cluster": "^0.59.0",
-        "@effect/platform": "^0.96.1",
-        "@effect/rpc": "^0.75.1",
-        "@effect/sql": "^0.51.1",
-        "effect": "^3.21.2"
+        "@effect/cluster": "^0.60.0",
+        "@effect/platform": "^0.97.0",
+        "@effect/rpc": "^0.76.0",
+        "@effect/sql": "^0.52.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/platform-node-shared": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@effect/platform-node-shared/-/platform-node-shared-0.60.0.tgz",
-      "integrity": "sha512-obT8Mau/guSYjehF9pg09FHM/ERXAAVBl/FXRXEyvTc7ZiDGTYnPBihytGNccsfNsgqBdvCE24sflwK6j5nFXA==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@effect/platform-node-shared/-/platform-node-shared-0.61.0.tgz",
+      "integrity": "sha512-68KbcnItrKFgDinFOmBVSABjcXBjp4vZbOUI3piFh87ZK/55vQ8+bwKGU4X7R9Vz1lSehyz5m2e7hwWVq3GNrg==",
       "license": "MIT",
       "dependencies": {
         "@parcel/watcher": "^2.5.1",
@@ -175,99 +175,99 @@
         "ws": "^8.18.2"
       },
       "peerDependencies": {
-        "@effect/cluster": "^0.59.0",
-        "@effect/platform": "^0.96.1",
-        "@effect/rpc": "^0.75.1",
-        "@effect/sql": "^0.51.1",
-        "effect": "^3.21.2"
+        "@effect/cluster": "^0.60.0",
+        "@effect/platform": "^0.97.0",
+        "@effect/rpc": "^0.76.0",
+        "@effect/sql": "^0.52.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/printer": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@effect/printer/-/printer-0.49.0.tgz",
-      "integrity": "sha512-hrjTuExF87wuWjOnnND1c2fKcCWhleQBVaoA7JlrU3rC7s+RYPETDOXtpgAK3/uuMCRnDhfVFQMevtKT8MBdKg==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@effect/printer/-/printer-0.50.0.tgz",
+      "integrity": "sha512-9tV9tNJS+Mjw+ZkBrfX3oUw9Kj5Ay61XMq0sONIUiBc6IgmJnLRmS12D/GTCVYncVmcX9zVrllhvN99StdcETg==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@effect/typeclass": "^0.40.0",
-        "effect": "^3.21.0"
+        "@effect/typeclass": "^0.41.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/printer-ansi": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@effect/printer-ansi/-/printer-ansi-0.49.0.tgz",
-      "integrity": "sha512-N2OyqDTqcGLKeUy2URowThoU5issZQwG/Ihv5qOYWJD0neq9qBIgC57/9BkFpTRPNSMtPHyCOk1TFj297HGLLQ==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@effect/printer-ansi/-/printer-ansi-0.50.0.tgz",
+      "integrity": "sha512-m2eVY1EcHRAQitweIcLUlZohRO4P96pyjiS8p31064CFddsY4qwXrP0I5h39T7D91gutM3Cru6VUDnw20rNyeA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@effect/printer": "^0.49.0"
+        "@effect/printer": "^0.50.0"
       },
       "peerDependencies": {
-        "@effect/typeclass": "^0.40.0",
-        "effect": "^3.21.0"
+        "@effect/typeclass": "^0.41.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/rpc": {
-      "version": "0.75.1",
-      "resolved": "https://registry.npmjs.org/@effect/rpc/-/rpc-0.75.1.tgz",
-      "integrity": "sha512-8yxF8+mMGGEbF8BUCp34HjdJj7CvTpGeZxBcpsDF6v7zPiGbJL1UDLzA8ZqYjmcngBHhPecbmeONTk/LiLAaEg==",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@effect/rpc/-/rpc-0.76.0.tgz",
+      "integrity": "sha512-51lcJtpy6ls9GnS6VqYBLeZq4xziUCHqdb/FkEDp9NO4WEIZfO+u/mfYUiAqMf3uiyr/GgrC1+JGIblf9Brqow==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "msgpackr": "^1.11.10"
       },
       "peerDependencies": {
-        "@effect/platform": "^0.96.1",
-        "effect": "^3.21.2"
+        "@effect/platform": "^0.97.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/sql": {
-      "version": "0.51.1",
-      "resolved": "https://registry.npmjs.org/@effect/sql/-/sql-0.51.1.tgz",
-      "integrity": "sha512-iPDAefrJcI0HcTk9keP9Gq8Pg08K1HmpnmZZt85AqyTcvorhoNsXDFiKBbPldfV2CortwVkacX8KjO9GPpSYCA==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@effect/sql/-/sql-0.52.0.tgz",
+      "integrity": "sha512-S7z9grD8QmuQDjM7VZLA3RsyQt9TKL/uSyjsz9Oz+gqBA4Espu+8dLDCc1OCWxVWUbUnfGH4L6rv4pSsX598iA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "uuid": "^11.0.3"
       },
       "peerDependencies": {
-        "@effect/experimental": "^0.60.0",
-        "@effect/platform": "^0.96.1",
-        "effect": "^3.21.2"
+        "@effect/experimental": "^0.61.0",
+        "@effect/platform": "^0.97.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/typeclass": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@effect/typeclass/-/typeclass-0.40.0.tgz",
-      "integrity": "sha512-L/2o2ImeqbemFlqH0b3y2PqQTFc+E0/DUnffCU8bkJUGh0yUZmh2RXuXhR8QOpfNCe718JQjI+mLnpVF2MMmaQ==",
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@effect/typeclass/-/typeclass-0.41.0.tgz",
+      "integrity": "sha512-Tsv94iDPUWgmz/JsYUh7awx5mmFukEJZB+duyzlLRlCHxNUz5LHBBzTaEfUPNMzAE1s8FTUSVwdPSpL0DznXKg==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "effect": "^3.21.0"
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/vitest": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@effect/vitest/-/vitest-0.29.0.tgz",
-      "integrity": "sha512-DvWr1aeEcaZ8mtu8hNVb4e3rEYvGEwQSr7wsNrW53t6nKYjkmjRICcvVEsXUhjoCblRHSxRsRV0TOt0+UmcvaQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@effect/vitest/-/vitest-0.30.0.tgz",
+      "integrity": "sha512-2qcK7F4XSwOn7Ye9vgEkrndHiiHVf9Nl+U5jvvLBKeYx4+8++O5Y8RFezaQzs/rWx8GkdlStv/s+HYMHZ/2/AQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "effect": "^3.21.0",
+        "effect": "^3.22.0",
         "vitest": "^3.2.0"
       }
     },
     "node_modules/@effect/workflow": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/@effect/workflow/-/workflow-0.18.2.tgz",
-      "integrity": "sha512-2av0TexhxHnapQa3eLn6TkniokUFRZKf8dlWlLqbODMpXAJ3mm+DOHWM0ozMGkg9K/+zGCtiL3dMqJyJ8r7G8g==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@effect/workflow/-/workflow-0.19.0.tgz",
+      "integrity": "sha512-9x84bADzhVWrglxWW3ts3LzoojMLAJ8SpR+Bv3YaZ3LToXrxTYnJZ29vR6X5VyK35rpQ7DtTruAT3JnQKmIEXw==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@effect/experimental": "^0.60.0",
-        "@effect/platform": "^0.96.1",
-        "@effect/rpc": "^0.75.1",
-        "effect": "^3.21.2"
+        "@effect/experimental": "^0.61.0",
+        "@effect/platform": "^0.97.0",
+        "@effect/rpc": "^0.76.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -3086,9 +3086,9 @@
       }
     },
     "node_modules/effect": {
-      "version": "3.21.4",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.4.tgz",
-      "integrity": "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.22.0.tgz",
+      "integrity": "sha512-jhYFe0zTlIRqYFrKTS+6luhmS/Tm0f+JLo0K9KUxvtFab1SUGEszQi2ehOP6QzAZvy831lDmTwwzvVDZSPNz3g==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",

--- a/plugins/kyosei/package.json
+++ b/plugins/kyosei/package.json
@@ -13,10 +13,10 @@
     "test": "vitest run --reporter=verbose"
   },
   "dependencies": {
-    "@effect/cli": "^0.75.1",
-    "@effect/platform": "^0.96.1",
-    "@effect/platform-node": "^0.107.0",
-    "effect": "^3.21.1",
+    "@effect/cli": "^0.76.0",
+    "@effect/platform": "^0.97.0",
+    "@effect/platform-node": "^0.108.0",
+    "effect": "^3.22.0",
     "fp-ts": "^2.16.11",
     "git-url-parse": "^16.1.0",
     "mustache": "^4.2.0",
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@effect/language-service": "0.87.0",
-    "@effect/vitest": "0.29.0",
+    "@effect/vitest": "0.30.0",
     "@eslint/js": "10.0.1",
     "@types/mustache": "4.2.6",
     "@types/node": "22.20.1",

--- a/plugins/pr/package-lock.json
+++ b/plugins/pr/package-lock.json
@@ -6,14 +6,14 @@
     "": {
       "name": "konoka-pr",
       "dependencies": {
-        "@effect/cli": "0.75.2",
-        "@effect/platform": "0.96.2",
-        "@effect/platform-node": "0.107.0",
-        "effect": "3.21.4"
+        "@effect/cli": "0.76.0",
+        "@effect/platform": "0.97.0",
+        "@effect/platform-node": "0.108.0",
+        "effect": "3.22.0"
       },
       "devDependencies": {
         "@effect/language-service": "0.87.0",
-        "@effect/vitest": "0.29.0",
+        "@effect/vitest": "0.30.0",
         "@eslint/js": "10.0.1",
         "@types/node": "22.20.1",
         "eslint": "10.7.0",
@@ -33,9 +33,9 @@
       }
     },
     "node_modules/@effect/cli": {
-      "version": "0.75.2",
-      "resolved": "https://registry.npmjs.org/@effect/cli/-/cli-0.75.2.tgz",
-      "integrity": "sha512-+cMn/ZtFB+jEvgB6phrTT6XyPkIUnmX4G0nUSln7yj3lwyiHQ578Iwr8nHeU1CKEtlh4Xt+mYc0yiT912xu7YA==",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@effect/cli/-/cli-0.76.0.tgz",
+      "integrity": "sha512-6N6u827Brlvf1UF3WMUazUgzZxq3kN/jemj66El7CUNulmlU7ciYKV0UMpETculvkKTfVonHZ5s49Fdz6Ad0cQ==",
       "license": "MIT",
       "dependencies": {
         "ini": "^4.1.3",
@@ -43,41 +43,41 @@
         "yaml": "^2.5.0"
       },
       "peerDependencies": {
-        "@effect/platform": "^0.96.1",
-        "@effect/printer": "^0.49.0",
-        "@effect/printer-ansi": "^0.49.0",
-        "effect": "^3.21.2"
+        "@effect/platform": "^0.97.0",
+        "@effect/printer": "^0.50.0",
+        "@effect/printer-ansi": "^0.50.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/cluster": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@effect/cluster/-/cluster-0.59.0.tgz",
-      "integrity": "sha512-rxtJ0zlcdDDtn9wau0z/PFfwPP2FsYPB2/tSK4tT8DkTYQmACJ5AwRwZm3Ea83iL/gv3df63lRe94oMiS8bFfg==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@effect/cluster/-/cluster-0.60.0.tgz",
+      "integrity": "sha512-O98Qx8jzEBhizhV/nOiqkZx+b0kx0AB1FBX+AKJ8wR8XO5Le44jqFzBwhwcoOVRhKVr2wzp3OE+IthipCVh4Mg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "kubernetes-types": "^1.30.0"
       },
       "peerDependencies": {
-        "@effect/platform": "^0.96.1",
-        "@effect/rpc": "^0.75.1",
-        "@effect/sql": "^0.51.1",
-        "@effect/workflow": "^0.18.2",
-        "effect": "^3.21.2"
+        "@effect/platform": "^0.97.0",
+        "@effect/rpc": "^0.76.0",
+        "@effect/sql": "^0.52.0",
+        "@effect/workflow": "^0.19.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/experimental": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@effect/experimental/-/experimental-0.60.0.tgz",
-      "integrity": "sha512-i5zIg7Xup2KgHyqHlYtkgqSE1bNzCL0GbbTQxrpIzKF0q/ebknOk/ox8B/gIq2vImjoEE81h/oxU+6i1NH210g==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@effect/experimental/-/experimental-0.61.0.tgz",
+      "integrity": "sha512-kv/ZORw2RMau74Q6Pco9/RTf/iXczBDqStHI9K8dP/1pUFq+dUMa4fHptuf3IIAe3tYdx4ALYsLyFLVcg+C5iQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "uuid": "^11.0.3"
       },
       "peerDependencies": {
-        "@effect/platform": "^0.96.0",
-        "effect": "^3.21.0",
+        "@effect/platform": "^0.97.0",
+        "effect": "^3.22.0",
         "ioredis": "^5",
         "lmdb": "^3"
       },
@@ -101,9 +101,9 @@
       }
     },
     "node_modules/@effect/platform": {
-      "version": "0.96.2",
-      "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.96.2.tgz",
-      "integrity": "sha512-oJm3UztdzZvK7BXkFSV3IdyGuqQrhLmViG/hMDZh99ski7aADesNuv19z4R0heH3bAXnSt/Nb8O9KJQ886C0Tg==",
+      "version": "0.97.0",
+      "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.97.0.tgz",
+      "integrity": "sha512-PPSKkQ+QlIbKcf74FZKi3pi2h8hqYjsrUYaFuWXsuHpr8gjUoNNxJBptYzkzy4X9f7EeHhHqDMcj9YxaMygiHg==",
       "license": "MIT",
       "dependencies": {
         "find-my-way-ts": "^0.1.6",
@@ -111,32 +111,32 @@
         "multipasta": "^0.2.7"
       },
       "peerDependencies": {
-        "effect": "^3.21.4"
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/platform-node": {
-      "version": "0.107.0",
-      "resolved": "https://registry.npmjs.org/@effect/platform-node/-/platform-node-0.107.0.tgz",
-      "integrity": "sha512-VWUD9SCcnsrXYqED2jIwDHHDGb3QePNsHlX7HfqQGD2/AgnfX9jNnecaFrJj7Rf2gK5VbRE+i/2oNFoC/DkhcA==",
+      "version": "0.108.0",
+      "resolved": "https://registry.npmjs.org/@effect/platform-node/-/platform-node-0.108.0.tgz",
+      "integrity": "sha512-AA8j4e7TOOzBOFAhYcwrtO0pGytiWxEpD7/xWs1nER+JyZI9la+Y506A72uWzc0GiOMBSPcsRmqc5zBjgImCZQ==",
       "license": "MIT",
       "dependencies": {
-        "@effect/platform-node-shared": "^0.60.0",
+        "@effect/platform-node-shared": "^0.61.0",
         "mime": "^3.0.0",
         "undici": "^7.10.0",
         "ws": "^8.18.2"
       },
       "peerDependencies": {
-        "@effect/cluster": "^0.59.0",
-        "@effect/platform": "^0.96.1",
-        "@effect/rpc": "^0.75.1",
-        "@effect/sql": "^0.51.1",
-        "effect": "^3.21.2"
+        "@effect/cluster": "^0.60.0",
+        "@effect/platform": "^0.97.0",
+        "@effect/rpc": "^0.76.0",
+        "@effect/sql": "^0.52.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/platform-node-shared": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@effect/platform-node-shared/-/platform-node-shared-0.60.0.tgz",
-      "integrity": "sha512-obT8Mau/guSYjehF9pg09FHM/ERXAAVBl/FXRXEyvTc7ZiDGTYnPBihytGNccsfNsgqBdvCE24sflwK6j5nFXA==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@effect/platform-node-shared/-/platform-node-shared-0.61.0.tgz",
+      "integrity": "sha512-68KbcnItrKFgDinFOmBVSABjcXBjp4vZbOUI3piFh87ZK/55vQ8+bwKGU4X7R9Vz1lSehyz5m2e7hwWVq3GNrg==",
       "license": "MIT",
       "dependencies": {
         "@parcel/watcher": "^2.5.1",
@@ -144,99 +144,99 @@
         "ws": "^8.18.2"
       },
       "peerDependencies": {
-        "@effect/cluster": "^0.59.0",
-        "@effect/platform": "^0.96.1",
-        "@effect/rpc": "^0.75.1",
-        "@effect/sql": "^0.51.1",
-        "effect": "^3.21.2"
+        "@effect/cluster": "^0.60.0",
+        "@effect/platform": "^0.97.0",
+        "@effect/rpc": "^0.76.0",
+        "@effect/sql": "^0.52.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/printer": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@effect/printer/-/printer-0.49.0.tgz",
-      "integrity": "sha512-hrjTuExF87wuWjOnnND1c2fKcCWhleQBVaoA7JlrU3rC7s+RYPETDOXtpgAK3/uuMCRnDhfVFQMevtKT8MBdKg==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@effect/printer/-/printer-0.50.0.tgz",
+      "integrity": "sha512-9tV9tNJS+Mjw+ZkBrfX3oUw9Kj5Ay61XMq0sONIUiBc6IgmJnLRmS12D/GTCVYncVmcX9zVrllhvN99StdcETg==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@effect/typeclass": "^0.40.0",
-        "effect": "^3.21.0"
+        "@effect/typeclass": "^0.41.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/printer-ansi": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@effect/printer-ansi/-/printer-ansi-0.49.0.tgz",
-      "integrity": "sha512-N2OyqDTqcGLKeUy2URowThoU5issZQwG/Ihv5qOYWJD0neq9qBIgC57/9BkFpTRPNSMtPHyCOk1TFj297HGLLQ==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@effect/printer-ansi/-/printer-ansi-0.50.0.tgz",
+      "integrity": "sha512-m2eVY1EcHRAQitweIcLUlZohRO4P96pyjiS8p31064CFddsY4qwXrP0I5h39T7D91gutM3Cru6VUDnw20rNyeA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@effect/printer": "^0.49.0"
+        "@effect/printer": "^0.50.0"
       },
       "peerDependencies": {
-        "@effect/typeclass": "^0.40.0",
-        "effect": "^3.21.0"
+        "@effect/typeclass": "^0.41.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/rpc": {
-      "version": "0.75.1",
-      "resolved": "https://registry.npmjs.org/@effect/rpc/-/rpc-0.75.1.tgz",
-      "integrity": "sha512-8yxF8+mMGGEbF8BUCp34HjdJj7CvTpGeZxBcpsDF6v7zPiGbJL1UDLzA8ZqYjmcngBHhPecbmeONTk/LiLAaEg==",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@effect/rpc/-/rpc-0.76.0.tgz",
+      "integrity": "sha512-51lcJtpy6ls9GnS6VqYBLeZq4xziUCHqdb/FkEDp9NO4WEIZfO+u/mfYUiAqMf3uiyr/GgrC1+JGIblf9Brqow==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "msgpackr": "^1.11.10"
       },
       "peerDependencies": {
-        "@effect/platform": "^0.96.1",
-        "effect": "^3.21.2"
+        "@effect/platform": "^0.97.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/sql": {
-      "version": "0.51.1",
-      "resolved": "https://registry.npmjs.org/@effect/sql/-/sql-0.51.1.tgz",
-      "integrity": "sha512-iPDAefrJcI0HcTk9keP9Gq8Pg08K1HmpnmZZt85AqyTcvorhoNsXDFiKBbPldfV2CortwVkacX8KjO9GPpSYCA==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@effect/sql/-/sql-0.52.0.tgz",
+      "integrity": "sha512-S7z9grD8QmuQDjM7VZLA3RsyQt9TKL/uSyjsz9Oz+gqBA4Espu+8dLDCc1OCWxVWUbUnfGH4L6rv4pSsX598iA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "uuid": "^11.0.3"
       },
       "peerDependencies": {
-        "@effect/experimental": "^0.60.0",
-        "@effect/platform": "^0.96.1",
-        "effect": "^3.21.2"
+        "@effect/experimental": "^0.61.0",
+        "@effect/platform": "^0.97.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/typeclass": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@effect/typeclass/-/typeclass-0.40.0.tgz",
-      "integrity": "sha512-L/2o2ImeqbemFlqH0b3y2PqQTFc+E0/DUnffCU8bkJUGh0yUZmh2RXuXhR8QOpfNCe718JQjI+mLnpVF2MMmaQ==",
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@effect/typeclass/-/typeclass-0.41.0.tgz",
+      "integrity": "sha512-Tsv94iDPUWgmz/JsYUh7awx5mmFukEJZB+duyzlLRlCHxNUz5LHBBzTaEfUPNMzAE1s8FTUSVwdPSpL0DznXKg==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "effect": "^3.21.0"
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@effect/vitest": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@effect/vitest/-/vitest-0.29.0.tgz",
-      "integrity": "sha512-DvWr1aeEcaZ8mtu8hNVb4e3rEYvGEwQSr7wsNrW53t6nKYjkmjRICcvVEsXUhjoCblRHSxRsRV0TOt0+UmcvaQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@effect/vitest/-/vitest-0.30.0.tgz",
+      "integrity": "sha512-2qcK7F4XSwOn7Ye9vgEkrndHiiHVf9Nl+U5jvvLBKeYx4+8++O5Y8RFezaQzs/rWx8GkdlStv/s+HYMHZ/2/AQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "effect": "^3.21.0",
+        "effect": "^3.22.0",
         "vitest": "^3.2.0"
       }
     },
     "node_modules/@effect/workflow": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/@effect/workflow/-/workflow-0.18.2.tgz",
-      "integrity": "sha512-2av0TexhxHnapQa3eLn6TkniokUFRZKf8dlWlLqbODMpXAJ3mm+DOHWM0ozMGkg9K/+zGCtiL3dMqJyJ8r7G8g==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@effect/workflow/-/workflow-0.19.0.tgz",
+      "integrity": "sha512-9x84bADzhVWrglxWW3ts3LzoojMLAJ8SpR+Bv3YaZ3LToXrxTYnJZ29vR6X5VyK35rpQ7DtTruAT3JnQKmIEXw==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@effect/experimental": "^0.60.0",
-        "@effect/platform": "^0.96.1",
-        "@effect/rpc": "^0.75.1",
-        "effect": "^3.21.2"
+        "@effect/experimental": "^0.61.0",
+        "@effect/platform": "^0.97.0",
+        "@effect/rpc": "^0.76.0",
+        "effect": "^3.22.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2662,9 +2662,9 @@
       }
     },
     "node_modules/effect": {
-      "version": "3.21.4",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.4.tgz",
-      "integrity": "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.22.0.tgz",
+      "integrity": "sha512-jhYFe0zTlIRqYFrKTS+6luhmS/Tm0f+JLo0K9KUxvtFab1SUGEszQi2ehOP6QzAZvy831lDmTwwzvVDZSPNz3g==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",

--- a/plugins/pr/package.json
+++ b/plugins/pr/package.json
@@ -12,14 +12,14 @@
     "test": "vitest run --reporter=verbose"
   },
   "dependencies": {
-    "@effect/cli": "0.75.2",
-    "@effect/platform": "0.96.2",
-    "@effect/platform-node": "0.107.0",
-    "effect": "3.21.4"
+    "@effect/cli": "0.76.0",
+    "@effect/platform": "0.97.0",
+    "@effect/platform-node": "0.108.0",
+    "effect": "3.22.0"
   },
   "devDependencies": {
     "@effect/language-service": "0.87.0",
-    "@effect/vitest": "0.29.0",
+    "@effect/vitest": "0.30.0",
     "@eslint/js": "10.0.1",
     "@types/node": "22.20.1",
     "eslint": "10.7.0",


### PR DESCRIPTION
commit・pr・kyoseiの3プラグインで、
effect関連パッケージを以下の通り更新します。

- `effect`: 3.21.4 → 3.22.0
- `@effect/cli`: 0.75.2 → 0.76.0
- `@effect/platform`: 0.96.2 → 0.97.0
- `@effect/platform-node`: 0.107.0 → 0.108.0
- `@effect/vitest`: 0.29.0 → 0.30.0

推移的依存の`@effect/printer`と`@effect/printer-ansi`も、
`@effect/cli`のpeer依存要求に合わせて0.50.0に更新されています。

全プラグインでlint・型チェック・テスト・buildが通ることを確認済みです。
