### PR TITLE
fix(pr): PR作成時にmaintainer_can_modifyをデフォルトで有効化します

### DIFF
--- a/plugins/pr/.claude-plugin/plugin.json
+++ b/plugins/pr/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "pr",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Create a GitHub pull request from the current branch.",
   "dependencies": ["commit"],
   "author": {

--- a/plugins/pr/skills/pr/SKILL.md
+++ b/plugins/pr/skills/pr/SKILL.md
@@ -164,6 +164,17 @@ PR作成に進んでください。
 - `title`: 生成したタイトル
 - `body`: 生成した本文
 - `draft`: ユーザが明示的に指示した場合のみ`true`、それ以外は省略
+- `maintainer_can_modify`: `true`
+
+`maintainer_can_modify`はGitHubの
+"Allow edits and access to secrets by maintainers"
+に対応します。
+forkからのPRでもmaintainerがブランチを直接修正できるように、
+常に有効化します。
+
+organizationが所有するforkからのPRなど、
+`maintainer_can_modify`が原因で作成が失敗した場合は、
+`maintainer_can_modify`を省略して作成し直してください。
 
 GitHubのPR作成APIはassigneesとlabelsの同時設定に対応していないため、
 これらは作成後に別ステップで設定します。

--- a/plugins/pr/skills/pr/SKILL.md
+++ b/plugins/pr/skills/pr/SKILL.md
@@ -163,12 +163,11 @@ PR作成に進んでください。
 - `base`: `sync-and-push`の出力の`base`
 - `title`: 生成したタイトル
 - `body`: 生成した本文
-- `draft`: ユーザが明示的に指示した場合のみ`true`、それ以外は省略
 - `maintainer_can_modify`: `true`
+- `draft`: ユーザが明示的に指示した場合のみ`true`、それ以外は省略
 
-`maintainer_can_modify`はGitHubの
-"Allow edits and access to secrets by maintainers"
-に対応します。
+`maintainer_can_modify`は、
+GitHubの`Allow edits and access to secrets by maintainers`に対応します。
 forkからのPRでもmaintainerがブランチを直接修正できるように、
 常に有効化します。
 


### PR DESCRIPTION
GitHubの"Allow edits and access to secrets by maintainers"に対応する引数、
`maintainer_can_modify`を、
`mcp__github__create_pull_request`の引数として常に`true`で渡すようにします。

forkからのPRでもmaintainerがブランチを直接修正できるようになり、
レビュー時の軽微な修正をmaintainer側で完結できます。

organizationが所有するforkからのPRなど、
このフラグが原因で作成に失敗するケースでは、
フラグを省略して作成し直すフォールバック手順も記載しています。

close #365