### PR TITLE
feat: ビルド済みプラグインをNix flakeのパッケージとして提供します

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ Claude Codeで以下を実行します。
 }
 ```
 
+### Nix flake
+
+ビルド済みのプラグインをNix flakeのパッケージとしても提供しています。
+
+一部のプラグインはTypeScriptやRust製のヘルパーを初回実行時にビルドしますが、
+nix storeは読み込み専用のためランタイムビルドが出来ません。
+flakeのパッケージはビルド生成物(`dist/`や`target/release/`)を同梱しているため、
+そのまま利用できます。
+
+`packages.<system>.konoka`(`default`)はマーケットプレイス全体のパッケージです。
+
+各プラグイン単体も`packages.<system>.<プラグイン名>`として提供しています。
+
 ## Development
 
 ### Setup

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ nix storeは読み込み専用のためランタイムビルドが出来ませ�
 flakeのパッケージはビルド生成物(`dist/`や`target/release/`)を同梱しているため、
 そのまま利用できます。
 
-`packages.<system>.konoka`(`default`)はマーケットプレイス全体のパッケージです。
+`packages.<system>.default`はマーケットプレイス全体のパッケージです。
 
 各プラグイン単体も`packages.<system>.<プラグイン名>`として提供しています。
 

--- a/flake.nix
+++ b/flake.nix
@@ -319,13 +319,15 @@
                     cargo build --release --frozen
                     runHook postBuild
                   '';
-                  # hooks.jsonが参照するパスに合わせてバイナリだけをtarget/releaseへ残し、
-                  # その他のビルド生成物と`cargoSetupHook`の設定は除外する。
+                  # hooks.jsonが参照するパスに合わせてバイナリだけをtarget/releaseへ残す。
+                  # 巨大なtarget/を丸ごとstoreへ書き込んでから消すのは無駄なため、
+                  # バイナリを配置した後にビルド生成物と`cargoSetupHook`の設定を取り除いてから、
+                  # 残りのプラグイン一式を複製する。
                   installPhase = ''
                     runHook preInstall
-                    cp -r . $out
-                    rm -rf $out/.cargo $out/target
                     install -Dm755 target/release/${pluginName} $out/target/release/${pluginName}
+                    rm -rf .cargo target
+                    cp -r . $out
                     runHook postInstall
                   '';
                 };

--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,22 @@
           };
           inherit (pkgs) nodejs;
 
+          # plugins/配下の実ディレクトリからプラグイン一覧を導出する。
+          # ビルド設定ファイルの有無で種別を判定するため、
+          # プラグインを追加してもここに手動で一覧を追記する必要はなく、
+          # パッケージ化やチェックからの漏れも起きない。
+          pluginDirOf = pluginName: ./plugins + "/${pluginName}";
+          pluginNames = lib.attrNames (
+            lib.filterAttrs (_name: type: type == "directory") (builtins.readDir ./plugins)
+          );
+          npmPluginNames = lib.filter (
+            pluginName: builtins.pathExists (pluginDirOf pluginName + "/package.json")
+          ) pluginNames;
+          rustPluginNames = lib.filter (
+            pluginName: builtins.pathExists (pluginDirOf pluginName + "/Cargo.toml")
+          ) pluginNames;
+          staticPluginNames = lib.subtractLists (npmPluginNames ++ rustPluginNames) pluginNames;
+
           # プラグインディレクトリのpackage.json/package-lock.jsonからnode_modulesを構築する。
           mkNodeModules =
             pluginDir:
@@ -120,11 +136,7 @@
                 lib.listToAttrs (map mkCheck scriptList);
             in
             lib.foldl' lib.mergeAttrs { } (
-              map mkPluginChecks [
-                ./plugins/commit
-                ./plugins/kyosei
-                ./plugins/pr
-              ]
+              map (pluginName: mkPluginChecks (pluginDirOf pluginName)) npmPluginNames
             );
 
           # プラグインディレクトリのリストから全Rustチェックのattrsetを生成する。
@@ -203,9 +215,7 @@
                 lib.listToAttrs (map mkCheck scriptList);
             in
             lib.foldl' lib.mergeAttrs { } (
-              map mkPluginChecks [
-                ./plugins/rm-to-trash
-              ]
+              map (pluginName: mkPluginChecks (pluginDirOf pluginName)) rustPluginNames
             );
 
           # プラグインのビルド済みパッケージ群。
@@ -213,7 +223,6 @@
           # ヘルパースクリプトのビルド生成物まで含めた完全なプラグインを提供する。
           pluginPackages =
             let
-              pluginDirOf = pluginName: ./plugins + "/${pluginName}";
               pluginVersionOf =
                 pluginName: (lib.importJSON (pluginDirOf pluginName + /.claude-plugin/plugin.json)).version;
               # ランタイムビルドの生成物と依存の展開先を除いたプラグインソース。
@@ -321,30 +330,21 @@
                   '';
                 };
             in
-            lib.genAttrs [
-              "haskell-tasuke"
-              "log-analyzer"
-              "nix-tasuke"
-              "programming-tasuke"
-              "proofreading-ja"
-              "research"
-              "web-tasuke"
-            ] mkStaticPlugin
-            // lib.genAttrs [
-              "commit"
-              "kyosei"
-              "pr"
-            ] mkNpmPlugin
-            // lib.genAttrs [
-              "rm-to-trash"
-            ] mkRustPlugin;
+            lib.genAttrs staticPluginNames mkStaticPlugin
+            // lib.genAttrs npmPluginNames mkNpmPlugin
+            // lib.genAttrs rustPluginNames mkRustPlugin;
 
           # マーケットプレイス全体をビルド済みプラグインで構成したパッケージ。
           # `/plugin marketplace add <storeパス>`でそのまま利用できる。
           konoka-marketplace =
             let
               marketplace = lib.importJSON ./.claude-plugin/marketplace.json;
+              marketplacePluginNames = lib.sort lib.lessThan (map (plugin: plugin.name) marketplace.plugins);
             in
+            # plugins/のディレクトリ一覧とmarketplace.jsonの登録内容の齟齬を評価時に検出する。
+            assert lib.assertMsg (
+              marketplacePluginNames == pluginNames
+            ) "marketplace.jsonのプラグイン一覧がplugins/のディレクトリ一覧と一致しません";
             pkgs.runCommand "konoka-${marketplace.metadata.version}" { } ''
               mkdir -p $out/.claude-plugin $out/plugins
               cp ${./.claude-plugin/marketplace.json} $out/.claude-plugin/marketplace.json

--- a/flake.nix
+++ b/flake.nix
@@ -299,6 +299,12 @@
                     rustPlatform.cargoSetupHook
                     rustc
                   ];
+                  # `.cargo/config.toml`の`target-cpu=native`はビルドしたマシンでのみ実行する前提の最適化だが、
+                  # このパッケージはバイナリキャッシュ経由で別CPUのマシンにも配布され得るため、
+                  # 最高優先度の`RUSTFLAGS`で汎用的なCPU水準に上書きする。
+                  # x86_64はClaude Codeが動作する程度のCPUを前提としてx86-64-v3に抑える。
+                  env.RUSTFLAGS =
+                    if pkgs.stdenv.hostPlatform.isx86_64 then "-C target-cpu=x86-64-v3" else "-C target-cpu=generic";
                   buildPhase = ''
                     runHook preBuild
                     cargo build --release --frozen

--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,30 @@
           };
           inherit (pkgs) nodejs;
 
+          # プラグインディレクトリのpackage.json/package-lock.jsonからnode_modulesを構築する。
+          mkNodeModules =
+            pluginDir:
+            pkgs.importNpmLock.buildNodeModules {
+              inherit nodejs;
+              npmRoot = lib.fileset.toSource {
+                root = pluginDir;
+                fileset = lib.fileset.unions [
+                  (pluginDir + "/package.json")
+                  (pluginDir + "/package-lock.json")
+                ];
+              };
+              derivationArgs = {
+                # `importNpmLock`は`npm install --ignore-scripts`で依存を展開するため、
+                # rootパッケージのprepareスクリプトが実行されない。
+                # `effect-language-service patch`がtscにパッチを当てて、
+                # effect診断をtscの診断の一部として有効化するパッケージがあるため、
+                # `node_modules`がまだ書き込み可能なこの段階でprepareを実行する。
+                preInstall = ''
+                  npm run --if-present prepare
+                '';
+              };
+            };
+
           # プラグインディレクトリのリストから全npmチェックのattrsetを生成する。
           pluginNpmChecks =
             let
@@ -57,26 +81,7 @@
                 pluginDir:
                 let
                   pluginName = builtins.baseNameOf pluginDir;
-                  npmRoot = lib.fileset.toSource {
-                    root = pluginDir;
-                    fileset = lib.fileset.unions [
-                      (pluginDir + "/package.json")
-                      (pluginDir + "/package-lock.json")
-                    ];
-                  };
-                  nodeModules = pkgs.importNpmLock.buildNodeModules {
-                    inherit nodejs npmRoot;
-                    derivationArgs = {
-                      # `importNpmLock`は`npm install --ignore-scripts`で依存を展開するため、
-                      # rootパッケージのprepareスクリプトが実行されない。
-                      # `effect-language-service patch`がtscにパッチを当てて、
-                      # effect診断をtscの診断の一部として有効化するパッケージがあるため、
-                      # `node_modules`がまだ書き込み可能なこの段階でprepareを実行する。
-                      preInstall = ''
-                        npm run --if-present prepare
-                      '';
-                    };
-                  };
+                  nodeModules = mkNodeModules pluginDir;
                   tsRoot = lib.fileset.toSource {
                     root = ./.;
                     fileset = lib.fileset.unions [
@@ -203,6 +208,147 @@
               ]
             );
 
+          # プラグインのビルド済みパッケージ群。
+          # nix store上のプラグインは読み込み専用でランタイムビルドが出来ないため、
+          # ヘルパースクリプトのビルド生成物まで含めた完全なプラグインを提供する。
+          pluginPackages =
+            let
+              pluginDirOf = pluginName: ./plugins + "/${pluginName}";
+              pluginVersionOf =
+                pluginName: (lib.importJSON (pluginDirOf pluginName + /.claude-plugin/plugin.json)).version;
+              # ランタイムビルドの生成物と依存の展開先を除いたプラグインソース。
+              pluginSourceOf =
+                pluginName:
+                let
+                  pluginDir = pluginDirOf pluginName;
+                in
+                lib.fileset.toSource {
+                  root = pluginDir;
+                  fileset = lib.fileset.difference pluginDir (
+                    lib.fileset.unions (
+                      map (name: lib.fileset.maybeMissing (pluginDir + "/${name}")) [
+                        ".build.lock"
+                        "dist"
+                        "node_modules"
+                        "target"
+                      ]
+                    )
+                  );
+                };
+              # ビルド不要のプラグインをそのままパッケージ化する。
+              mkStaticPlugin =
+                pluginName:
+                pkgs.stdenv.mkDerivation {
+                  pname = "konoka-plugin-${pluginName}";
+                  version = pluginVersionOf pluginName;
+                  src = pluginSourceOf pluginName;
+                  installPhase = ''
+                    runHook preInstall
+                    cp -r . $out
+                    runHook postInstall
+                  '';
+                };
+              # TypeScript製ヘルパーをビルドしてdistを同梱する。
+              mkNpmPlugin =
+                pluginName:
+                let
+                  nodeModules = mkNodeModules (pluginDirOf pluginName);
+                in
+                pkgs.stdenv.mkDerivation {
+                  pname = "konoka-plugin-${pluginName}";
+                  version = pluginVersionOf pluginName;
+                  src = pluginSourceOf pluginName;
+                  nativeBuildInputs = [
+                    nodejs
+                    pkgs.makeWrapper
+                  ];
+                  buildPhase = ''
+                    runHook preBuild
+                    ln -s ${nodeModules}/node_modules node_modules
+                    npm run build
+                    runHook postBuild
+                  '';
+                  installPhase = ''
+                    runHook preInstall
+                    rm node_modules
+                    cp -r . $out
+                    runHook postInstall
+                  '';
+                  # binのスクリプトはnodeをPATHから探すため、
+                  # スクリプト本体は無改変のままラップしてランタイム依存としてnodeを付与する。
+                  postInstall = ''
+                    if [ -d "$out/bin" ]; then
+                      for script in "$out"/bin/*; do
+                        wrapProgram "$script" --prefix PATH : ${lib.makeBinPath [ nodejs ]}
+                      done
+                    fi
+                  '';
+                };
+              # Rust製フックバイナリをビルドしてtarget/releaseに同梱する。
+              mkRustPlugin =
+                pluginName:
+                pkgs.stdenv.mkDerivation {
+                  pname = "konoka-plugin-${pluginName}";
+                  version = pluginVersionOf pluginName;
+                  src = pluginSourceOf pluginName;
+                  cargoDeps = pkgs.rustPlatform.importCargoLock {
+                    lockFile = pluginDirOf pluginName + "/Cargo.lock";
+                  };
+                  nativeBuildInputs = with pkgs; [
+                    cargo
+                    rustPlatform.cargoSetupHook
+                    rustc
+                  ];
+                  buildPhase = ''
+                    runHook preBuild
+                    cargo build --release --frozen
+                    runHook postBuild
+                  '';
+                  # hooks.jsonが参照するパスに合わせてバイナリだけをtarget/releaseへ残し、
+                  # その他のビルド生成物と`cargoSetupHook`の設定は除外する。
+                  installPhase = ''
+                    runHook preInstall
+                    cp -r . $out
+                    rm -rf $out/.cargo $out/target
+                    install -Dm755 target/release/${pluginName} $out/target/release/${pluginName}
+                    runHook postInstall
+                  '';
+                };
+            in
+            lib.genAttrs [
+              "haskell-tasuke"
+              "log-analyzer"
+              "nix-tasuke"
+              "programming-tasuke"
+              "proofreading-ja"
+              "research"
+              "web-tasuke"
+            ] mkStaticPlugin
+            // lib.genAttrs [
+              "commit"
+              "kyosei"
+              "pr"
+            ] mkNpmPlugin
+            // lib.genAttrs [
+              "rm-to-trash"
+            ] mkRustPlugin;
+
+          # マーケットプレイス全体をビルド済みプラグインで構成したパッケージ。
+          # `/plugin marketplace add <storeパス>`でそのまま利用できる。
+          konoka-marketplace =
+            let
+              marketplace = lib.importJSON ./.claude-plugin/marketplace.json;
+            in
+            pkgs.runCommand "konoka-${marketplace.metadata.version}" { } ''
+              mkdir -p $out/.claude-plugin $out/plugins
+              cp ${./.claude-plugin/marketplace.json} $out/.claude-plugin/marketplace.json
+              ${lib.concatStrings (
+                lib.mapAttrsToList (pluginName: plugin: ''
+                  ln -s ${plugin} $out/plugins/${pluginName}
+                '') pluginPackages
+              )}
+            '';
+
           agnix = pkgs.callPackage ./pkgs/agnix/package.nix { };
 
           agnixSrc = lib.fileset.toSource {
@@ -255,14 +401,21 @@
                 '';
           }
           // pluginNpmChecks
-          // pluginRustChecks;
+          // pluginRustChecks
+          # プラグインパッケージのビルドもチェック対象に含める。
+          // lib.mapAttrs' (pluginName: lib.nameValuePair "package-${pluginName}") (
+            pluginPackages // { konoka = konoka-marketplace; }
+          );
 
           packages = {
             # flake.lockの管理バージョンをre-exportすることで安定した利用を促進。
             inherit (pkgs)
               nix-fast-build
               ;
-          };
+            default = konoka-marketplace;
+          }
+          // pluginPackages;
+
           devShells.default = pkgs.mkShell {
             buildInputs = with pkgs; [
               # treefmtで指定したプログラムの単体版。


### PR DESCRIPTION
一部のプラグインはTypeScriptやRust製のヘルパースクリプトを、
初回実行時のフックでランタイムビルドしています。
しかしflake経由で参照した場合はnix store上に配置され、
読み込み専用のためランタイムビルドが出来ません。
そこでビルド生成物まで含めた完全なプラグインをパッケージとして提供します。

- npm系(commit・kyosei・pr)は`vite build`した`dist/`を同梱します。
  既存チェックの`importNpmLock.buildNodeModules`は`mkNodeModules`として共通化し、
  チェックとパッケージの両方から利用します。
- Rust系(rm-to-trash)は`hooks.json`が参照するパスに合わせて、
  `target/release/`にビルド済みバイナリを同梱します。
- ビルド不要のプラグインもそのまま`packages.<system>.<プラグイン名>`として提供します。

`packages.<system>.default`はマーケットプレイス全体のパッケージで、
`.claude-plugin/marketplace.json`とビルド済みプラグインを束ねているため、
storeパスをそのまま`/plugin marketplace add`に渡せます。

commitとprのbinラッパーは`node`をPATHから探すため、
スクリプト本体は無改変のまま`wrapProgram`でラップして、
ランタイム依存としてnodejsを付与します。
利用側の環境にNode.jsが無くても動作します。

各パッケージのビルドは`package-<名前>`としてchecksにも含めて、
CIで継続的に検証されるようにします。

プラグイン本体の内容は無変更のためプラグインバージョンは変更しません。
