### PR TITLE
refactor: agnix設定を複数ツール対応のtools形式へ移行します

### DIFF
--- a/.agnix.toml
+++ b/.agnix.toml
@@ -1,29 +1,29 @@
-target = "ClaudeCode"
+tools = [
+"claude-code",
+"opencode",
+"github-copilot",
+"generic",
+]
 
 [rules]
-skills = true
-hooks = true
-agents = true
-memory = true
-plugins = true
-xml = true
-mcp = true
-imports = true
-cross_platform = true
-copilot = true
-prompt_engineering = true
-generic_instructions = true
-frontmatter_validation = true
-xml_balance = true
-import_references = true
-
-codex = false
+skills = true              # AS-*, CC-SK-* rules
+hooks = true               # CC-HK-* rules
+agents = true              # CC-AG-* rules
+copilot = true             # COP-* rules
+cursor = true              # CUR-* rules
+memory = true              # CC-MEM-* rules
+plugins = true             # CC-PL-* rules
+mcp = true                 # MCP-* rules
+prompt_engineering = true  # PE-* rules
+xml = true                 # XML-* rules
+imports = true             # REF-* rules
+cross_platform = true      # XP-* rules
+agents_md = true           # AGM-* rules
 
 disabled_rules = [
-"CC-AG-009",                    # `mcp__github`など、`mcp__<server>`のワイルドカードを許容。
-"CC-SK-007",                    # log-analyzerは任意コマンドを実行してログを採取する用途なので、Bashをスコープ制限できない。
-"CC-SK-008",                    # CC-AG-009と同じくスキルのallowed-toolsでも`mcp__<server>`のワイルドカードを許容。
-"CC-SK-013",                    # 英語の命令型動詞のみで判定するため日本語スキルでは常に誤検知する。
-"VER-001",                      # 新しくなって警告が発生したらそれに対応するだけなのでPINする理由がない。
-"XP-SK-001",                    # Claude Codeの固有機能が使いたいので互換性は犠牲にします。
+"CC-SK-007", # log-analyzerは任意コマンドを実行するので、Bashをスコープ制限できない。
+"CC-SK-008", # `mcp__github`など、`mcp__<server>`のワイルドカードを許容。
+"CC-SK-013", # 英語の命令型動詞のみで判定するため日本語スキルでは常に誤検知する。
+"VER-001",   # 新しくなって警告が発生したらそれに対応するだけなのでPINする理由がない。
+"XP-SK-001", # Claude Codeの固有機能の使用を許可する。
 ]


### PR DESCRIPTION
単一指定の`target`キーを`tools`配列へ置き換えて、
claude-codeに加えてopencode・github-copilot・genericも検証対象にします。

rulesセクションは現行のルールカテゴリ一覧に合わせて整理して、
各キーに対応するルールprefixをコメントで併記します。
cursorとagents_mdのカテゴリを新たに有効化します。

前回の変更で`agents/`ディレクトリ自体が無くなったため、
エージェント向けの除外だった`CC-AG-009`をdisabled_rulesから外し、
残る各ルールのコメントも現状に合わせて簡潔にします。
