### PR TITLE
build(deps): dependの記述方法をsemver形式に統一

### DIFF
--- a/plugins/commit/package-lock.json
+++ b/plugins/commit/package-lock.json
@@ -6,10 +6,10 @@
     "": {
       "name": "konoka-commit",
       "dependencies": {
-        "@effect/cli": "0.77.0",
-        "@effect/platform": "0.97.1",
-        "@effect/platform-node": "0.108.0",
-        "effect": "3.22.1"
+        "@effect/cli": "^0.77.0",
+        "@effect/platform": "^0.97.1",
+        "@effect/platform-node": "^0.108.0",
+        "effect": "^3.22.1"
       },
       "devDependencies": {
         "@effect/language-service": "0.87.1",

--- a/plugins/commit/package.json
+++ b/plugins/commit/package.json
@@ -12,10 +12,10 @@
     "test": "vitest run --reporter=verbose"
   },
   "dependencies": {
-    "@effect/cli": "0.77.0",
-    "@effect/platform": "0.97.1",
-    "@effect/platform-node": "0.108.0",
-    "effect": "3.22.1"
+    "@effect/cli": "^0.77.0",
+    "@effect/platform": "^0.97.1",
+    "@effect/platform-node": "^0.108.0",
+    "effect": "^3.22.1"
   },
   "devDependencies": {
     "@effect/language-service": "0.87.1",

--- a/plugins/pr/package-lock.json
+++ b/plugins/pr/package-lock.json
@@ -6,10 +6,10 @@
     "": {
       "name": "konoka-pr",
       "dependencies": {
-        "@effect/cli": "0.77.0",
-        "@effect/platform": "0.97.1",
-        "@effect/platform-node": "0.108.0",
-        "effect": "3.22.1"
+        "@effect/cli": "^0.77.0",
+        "@effect/platform": "^0.97.1",
+        "@effect/platform-node": "^0.108.0",
+        "effect": "^3.22.1"
       },
       "devDependencies": {
         "@effect/language-service": "0.87.1",

--- a/plugins/pr/package.json
+++ b/plugins/pr/package.json
@@ -12,10 +12,10 @@
     "test": "vitest run --reporter=verbose"
   },
   "dependencies": {
-    "@effect/cli": "0.77.0",
-    "@effect/platform": "0.97.1",
-    "@effect/platform-node": "0.108.0",
-    "effect": "3.22.1"
+    "@effect/cli": "^0.77.0",
+    "@effect/platform": "^0.97.1",
+    "@effect/platform-node": "^0.108.0",
+    "effect": "^3.22.1"
   },
   "devDependencies": {
     "@effect/language-service": "0.87.1",


### PR DESCRIPTION
現在使っているrenovateのプリセットが設定する形式は、
`devDependencies`だけ完全にpinして、
`dependencies`はpinしないことですが、
kyosei以外はそうなっていませんでした。
混乱を防ぐためにリポジトリで統一します。
