### PR TITLE
fix(commit,pr): スキルの`effort`を`low`に下げます

### DIFF
--- a/plugins/commit/.claude-plugin/plugin.json
+++ b/plugins/commit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "commit",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "Generate a commit message from staged changes and let the user review before committing. Use when the user wants to commit changes or create a git commit.",
   "author": {
     "name": "ncaq",

--- a/plugins/commit/skills/commit-style/SKILL.md
+++ b/plugins/commit/skills/commit-style/SKILL.md
@@ -3,7 +3,7 @@ name: commit-style
 description: Commit message style guidelines. Use when writing or proposing git commit messages, including direct git commit commands outside the /commit skill.
 allowed-tools: Bash(git log:*), Bash(read-commit-instructions:*)
 user-invocable: false
-effort: medium
+effort: low
 ---
 
 コミットメッセージを書く際のスタイルガイドラインです。

--- a/plugins/commit/skills/commit/SKILL.md
+++ b/plugins/commit/skills/commit/SKILL.md
@@ -3,7 +3,7 @@ name: commit
 description: Generate a commit message from staged changes and let the user review before committing. Use when the user wants to commit changes or create a git commit.
 allowed-tools: AskUserQuestion, Bash(commit-prepare:*), Bash(git commit:*), Bash(konoka-commit-editor:*), Edit, Read, Write, Skill(commit-style)
 model: opus
-effort: medium
+effort: low
 ---
 
 Gitリポジトリの変更をコミットします。

--- a/plugins/pr/.claude-plugin/plugin.json
+++ b/plugins/pr/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "pr",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Create a GitHub pull request from the current branch.",
   "dependencies": ["commit"],
   "author": {

--- a/plugins/pr/skills/pr-style/SKILL.md
+++ b/plugins/pr/skills/pr-style/SKILL.md
@@ -3,7 +3,7 @@ name: pr-style
 description: Pull request style guidelines covering title, body, assignee, and label selection. Use when writing or proposing GitHub pull requests, including direct `gh pr create` invocations outside the /pr skill.
 allowed-tools: Bash(gh label list:*), Bash(gh pr list:*), Bash(gh pr view:*), Bash(gh repo view:*), Bash(git diff:*), Bash(git log:*), Bash(read-contributing:*), Bash(read-pull-request-template:*), mcp__github__get_me, mcp__github__list_pull_requests, mcp__github__pull_request_read
 user-invocable: false
-effort: medium
+effort: low
 ---
 
 GitHubのpull requestを作成するときのスタイルガイドラインです。

--- a/plugins/pr/skills/pr/SKILL.md
+++ b/plugins/pr/skills/pr/SKILL.md
@@ -3,7 +3,7 @@ name: pr
 description: Generate a GitHub pull request title and body from the current branch and let the user review before creation. Use when the user wants to create a pull request.
 allowed-tools: AskUserQuestion, Bash(git status:*), Bash(konoka-pr-editor:*), Bash(prepare-editmsg:*), Bash(sync-and-push:*), Edit, Read, Skill(pr-style), Write, mcp__github__create_pull_request, mcp__github__issue_write
 model: opus
-effort: medium
+effort: low
 ---
 
 GitHubのpull requestを作成します。


### PR DESCRIPTION
コミットとpull requestの作成は、
定型的な内容の生成が中心で、
深い推論を必要とする要素がほとんどありません。

それにも関わらず`effort: medium`では、
コミットメッセージやPR本文が出来上がった後も、
モデルが不必要に考え込んで応答が遅くなることが多くありました。

`commit`と`commit-style`、
`pr`と`pr-style`の4つのスキル全てを`effort: low`に変更し、
生成の速度を優先します。

スタイルガイドラインの適用や差分の要約は、
`low`でも十分に行える範囲の作業です。
